### PR TITLE
DOC: Changes to docs to account for switching of repo ownership.

### DIFF
--- a/act/utils/ship_utils.py
+++ b/act/utils/ship_utils.py
@@ -19,8 +19,9 @@ def calc_cog_sog(obj):
 
     Function is set up to use dask for the calculations in order to improve
     efficiency. Data are then resampled to 1 second to match native format.
-    This assumes that the input data are 1 second.  See example:
-    https://anl-digr.github.io/ACT/source/auto_examples/correct_ship_wind_data.html#sphx-glr-source-auto-examples-correct-ship-wind-data-py
+    This assumes that the input data are 1 second.  See this `example
+    <https://ARM-DOE.github.io/ACT/source/auto_examples/correct_ship_wind_data.html
+    #sphx-glr-source-auto-examples-correct-ship-wind-data-py>`_.
 
     Parameters
     ----------

--- a/docs/source/CONTRIBUTING.rst
+++ b/docs/source/CONTRIBUTING.rst
@@ -13,7 +13,7 @@ Types of Contributions
 Report Bugs
 ~~~~~~~~~~~
 
-Report bugs at https://github.com/ANL-DIGR/ACT/issues
+Report bugs at https://github.com/ARM-DOE/ACT/issues
 
 If you are reporting a bug, please include:
 
@@ -42,7 +42,7 @@ or even on the web in blog posts, articles, and such.
 Submit Feedback
 ~~~~~~~~~~~~~~~
 
-The best way to send feedback is to file an issue at https://github.com/ANL-DIGR/ACT/issues
+The best way to send feedback is to file an issue at https://github.com/ARM-DOE/ACT/issues
 
 If you are proposing a feature:
 
@@ -78,7 +78,7 @@ Fork and Cloning the ACT Repository
 To start, you will first fork the `ACT` repo on GitHub by
 clicking the fork icon button found on the main page here:
 
-- https://github.com/ANL-DIGR/ACT
+- https://github.com/ARM-DOE/ACT
 
 After your fork is created, git clone your fork. I would not clone the main
 repository link unless your just using the package as an install and not
@@ -95,7 +95,7 @@ or if you have ssh key setup::
 
 After that, from within the ACT directory, do::
 
-    git remote add upstream https://github.com/ANL-DIGR/ACT.git
+    git remote add upstream https://github.com/ARM-DOE/ACT.git
 
 Install
 -------
@@ -110,7 +110,7 @@ From within the ACT directory, you can use::
 This downloads ACT in development mode. Do this preferably in a conda
 environment. For more on Anaconda and environments:
 
-- https://anl-digr.github.io/ACT/CREATING_ENVIRONMENTS.html
+- https://ARM-DOE.github.io/ACT/CREATING_ENVIRONMENTS.html
 
 Working with Git Branches
 -------------------------
@@ -410,7 +410,7 @@ Before you submit a pull request, check that it meets these guidelines:
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
 3. The pull request should work for Python 2.7, 3.6, 3.7 for PyPy. Check
-   https://travis-ci.org/ANL-DIGR/ACT
+   https://travis-ci.org/ARM-DOE/ACT
    and make sure that the tests pass for all supported Python versions.
 
 After creating a pull request through GitHub, and outside checker TravisCI

--- a/docs/source/CREATING_ENVIRONMENTS.rst
+++ b/docs/source/CREATING_ENVIRONMENTS.rst
@@ -49,7 +49,7 @@ Creating an Environment
 There are a few ways to create a conda environment for using ACT or other
 packages. One way is to use the environment file, found here:
 
-* https://github.com/ANL-DIGR/ACT/blob/master/environment.yml
+* https://github.com/ARM-DOE/ACT/blob/master/environment.yml
 
 To create an environment using this file, use the command::
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -17,7 +17,9 @@ Or, if you have Anaconda::
 You can build the Atmospheric data Community Toolkit from source and install it doing::
 
 
-    $ git clone https://github.com/ANL-DIGR/ACT
+    $ git clone https://github.com/ARM-DOE/ACT
     $ cd ACT
     $ python setup.py install
+
+We soon plan to implement pip install and conda install features. 
 

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -2,10 +2,80 @@
 Release History
 ===============
 
-0.1 (Released 2019-03-21)
+0.1.6 (Released 2019-12-02)
+---------------------------
+
+Numerous updates have been made since the last release.
+
+* The ACT object has been updated to remove the "act" attributes
+  and instead store that information in xarrays attrs.
+  Code has also been updated to not need additional information
+  that is adding in during the reading so that pure xarray datasets can be used.
+
+* Corrections to the doppler lidar correction, wind barb plotting, sonde stability calculations.
+
+* Adding doppler lidar wind retrievals, code to calculate destination lat/lon
+  from starting lat/lon and heading/distance
+
+
+0.1.6 (Released 2019-10-10)
+---------------------------
+
+* Corrections for Doppler Lidar, Raman Lidar added as well as updates to MPL correction code
+* New plotting capability for plotting size spectra
+* Added capability to calculate course and speed over ground from lat/lon data
+* Added capability to correct wind speed and direction for ship motion
+* Removing ACT rolling_window function
+
+0.1.5 (Released 2019-09-20)
+---------------------------
+
+The recent update to xarray caused some issues with the tests.
+These have been updated to accommodate
+
+0.1.4 (Released 2019-09-20)
+---------------------------
+
+Version includes new plotting functions for visualizing
+bit-packed QC as used by the ARM program. A new function
+for calculating precipitable water vapor from a sounding
+was also created and including. Other updates include bug
+fixes and the inclusion of a roadmap.
+
+0.1.3 (Released 2019-09-06)
+---------------------------
+
+Merge pull request #116 from AdamTheisen/master
+
+Missing requirements and data files for tests
+
+0.1.2 (Released 2019-09-06)
+---------------------------
+
+Some .txt files were missing from the pip installs.
+
+0.1.1 (Released 2019-09-03)
+---------------------------
+
+This release is to support the anaconda distribution.
+
+0.1 (Released 2019-09-03)
 -------------------------
 
-* Support for reading ARM datasets that are timeseries, either 1D or 2D
-* Ability to download data from ARM datastreams
-* Ability to make multipanel timeseries plots
+Additional documentation for the QC functions have been added.
+New functions for weighted averaging of time-series data, precipitation
+accumulation, and cloud base height detection using a sobel edge
+detection method have also been added.
 
+0.0.2 (Released 2019-08-14)
+---------------------------
+
+Secondary release to work with pypi
+
+0.0.1 (Released 2019-08-14)
+---------------------------
+
+This is the initial release of the ACT toolkit for use in working with
+atmospheric time-series data. Library includes scripts for accessing
+data through APIs, I/O scripts, data visualization, quality control
+algorithms, corrections, and retrievals.


### PR DESCRIPTION
Making required changes in the documentation to account for the change in the ACT repo's ownership. The largest change is that the new website is now at https://ARM-DOE.github.io/ACT.

I also updated the release history to be current.