### PR TITLE
Fixing issue when plotting data with lat and lon as vectors with day_ight_background set.

### DIFF
--- a/act/plotting/TimeSeriesDisplay.py
+++ b/act/plotting/TimeSeriesDisplay.py
@@ -137,11 +137,11 @@ class TimeSeriesDisplay(Display):
 
         try:
             if self._arm[dsname].lat.data.size > 1:
-                lat = self._arm[dsname][lat_name].data[0]
-                lon = self._arm[dsname][lon_name].data[0]
+                lat = self._arm[dsname][lat_name].values[0]
+                lon = self._arm[dsname][lon_name].values[0]
             else:
-                lat = float(self._arm[dsname][lat_name].data)
-                lon = float(self._arm[dsname][lon_name].data)
+                lat = float(self._arm[dsname][lat_name].values)
+                lon = float(self._arm[dsname][lon_name].values)
         except AttributeError:
             return
 


### PR DESCRIPTION
There is a problem when plotting data that have lat/lon as vectors when making the day night background. Just changed the method for getting data from .data to .values to return numpy array instead of dask object.