### PR TITLE
FIX: Handling of improper user name in data discovery download tool.

### DIFF
--- a/act/discovery/get_armfiles.py
+++ b/act/discovery/get_armfiles.py
@@ -89,8 +89,8 @@ def download_data(username, token, datastream,
     response_body = urlopen(query_url).read().decode("utf-8")
     # if the response is an html doc, then there was an error with the user
     if response_body[1:14] == "!DOCTYPE html":
-        print("Error with user. Check username or token.")
-        exit(1)
+        raise ConnectionRefusedError("Error with user. Check username or token.")
+        
     # parse into json object
     response_body_json = json.loads(response_body)
 

--- a/act/discovery/get_armfiles.py
+++ b/act/discovery/get_armfiles.py
@@ -90,7 +90,7 @@ def download_data(username, token, datastream,
     # if the response is an html doc, then there was an error with the user
     if response_body[1:14] == "!DOCTYPE html":
         raise ConnectionRefusedError("Error with user. Check username or token.")
-        
+
     # parse into json object
     response_body_json = json.loads(response_body)
 


### PR DESCRIPTION
When a user placed improper login information to the ARM Data Discovery download tool it would display an error message and then exit the python program. However, it would fail at doing so because sys.exit was not imported correctly. I've changed this to have a more proper behavior where an exception is raised rather than exiting the entire program.