### PR TITLE
Fixing 2D heights

### DIFF
--- a/act/corrections/mpl.py
+++ b/act/corrections/mpl.py
@@ -71,6 +71,13 @@ def correct_mpl(obj, co_pol_var_name='signal_return_co_pol',
     if len(op_height.shape) > 1:
         op_height = op_height[0, :]
 
+    # Check if height has dimentionality of time and height. If so reduce height
+    # to only dimentionality of height in object before removing values less than 0.
+    if len(obj[height_var_name].shape) > 1:
+        reduce_dim_name = {'time'} & set(obj[height_var_name].dims)
+        obj[height_var_name] = obj[height_var_name].reduce(
+            func=np.median, dim=reduce_dim_name, keep_attrs=True)
+
     # 1 - Remove negative height data
     obj = obj.where(obj[height_var_name] > 0., drop=True)
     height = obj[height_var_name].values

--- a/act/corrections/mpl.py
+++ b/act/corrections/mpl.py
@@ -26,6 +26,11 @@ def correct_mpl(obj, co_pol_var_name='signal_return_co_pol',
     4.) Range Correction.
     5.) Overlap Correction (Multiply).
 
+    If the height variable changes between netCDF files, Xarray will turn the height
+    dimention variables from a 1D to a 2D array. This will cause issues with processing
+    and other data manipulation. To fix this the 2D height will be converted to a 1D
+    array by using the median value for each height value.
+
     Note: Deadtime and darkcount corrections are not being applied yet.
 
     Parameters


### PR DESCRIPTION
Adding correction if height dimension is 2D instead of expected 1D. This happens when xarray combines multiple files and the coordinate dimension changes values or shape between files. This is causing issues to subset height to positive values only.