### PR TITLE
ENH: Improved detection of properly installed MetPy

### DIFF
--- a/act/plotting/SkewTDisplay.py
+++ b/act/plotting/SkewTDisplay.py
@@ -9,11 +9,18 @@ Stores the class for SkewTDisplay.
 # Import third party libraries
 import matplotlib.pyplot as plt
 import numpy as np
+import warnings
 
 try:
+    from pkg_resources import DistributionNotFound
     import metpy.calc as mpcalc
     METPY_AVAILABLE = True
 except ImportError:
+    METPY_AVAILABLE = False
+except (ModuleNotFoundError, DistributionNotFound):
+    warnings.warn("MetPy is installed but could not be imported. " + \
+                  "Please check your MetPy installation. Some features "+ 
+                  "will be disabled.", ImportWarning)
     METPY_AVAILABLE = False
 
 # Import Local Libs

--- a/act/plotting/SkewTDisplay.py
+++ b/act/plotting/SkewTDisplay.py
@@ -18,8 +18,8 @@ try:
 except ImportError:
     METPY_AVAILABLE = False
 except (ModuleNotFoundError, DistributionNotFound):
-    warnings.warn("MetPy is installed but could not be imported. " + \
-                  "Please check your MetPy installation. Some features "+ 
+    warnings.warn("MetPy is installed but could not be imported. " + 
+                  "Please check your MetPy installation. Some features " +
                   "will be disabled.", ImportWarning)
     METPY_AVAILABLE = False
 

--- a/act/plotting/SkewTDisplay.py
+++ b/act/plotting/SkewTDisplay.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     METPY_AVAILABLE = False
 except (ModuleNotFoundError, DistributionNotFound):
-    warnings.warn("MetPy is installed but could not be imported. " + 
+    warnings.warn("MetPy is installed but could not be imported. " +
                   "Please check your MetPy installation. Some features " +
                   "will be disabled.", ImportWarning)
     METPY_AVAILABLE = False

--- a/act/retrievals/stability_indices.py
+++ b/act/retrievals/stability_indices.py
@@ -5,13 +5,19 @@ act.retrievals.stability_indices
 Module that adds stability indicies to a dataset.
 
 """
-import xarray as xr
+import warnings
 import numpy as np
 
 try:
+    from pkg_resources import DistributionNotFound
     import metpy.calc as mpcalc
     METPY_AVAILABLE = True
 except ImportError:
+    METPY_AVAILABLE = False
+except (ModuleNotFoundError, DistributionNotFound):
+    warnings.warn("MetPy is installed but could not be imported. " +
+                  "Please check your MetPy installation. Some features " +
+                  "will be disabled.", ImportWarning)
     METPY_AVAILABLE = False
 
 if METPY_AVAILABLE:


### PR DESCRIPTION
This addresses #194, where I add in a few more exceptions in case there is an improper MetPy installation. 