### PR TITLE
Clean try

### DIFF
--- a/act/qc/clean.py
+++ b/act/qc/clean.py
@@ -182,8 +182,12 @@ class CleanDataset(object):
                 found_dtype = False
                 for att_name in ['flag_masks', 'flag_values']:
                     try:
-                        data = data.astype(
-                            self._obj[var].attrs[att_name].dtype)
+                        att_value = self._obj[var].attrs[att_name]
+                        if isinstance(att_value, (list, tuple)):
+                            dtype = att_value[0].dtype
+                        else:
+                            dtype = att_value.dtype
+                        data = data.astype(dtype)
                         found_dtype = True
                         break
                     except (KeyError, IndexError):


### PR DESCRIPTION
There is an issue when checking for variables incorrectly upconverted from int to float when xarray finds missing_value attributes. This function will try to revert the float back to int for things like QC and state type variables. This error was incorrectly catching errors while trying to guess the correct numpy dtype.