### PR TITLE
Fixing issue with making numpy mask

### DIFF
--- a/act/qc/clean.py
+++ b/act/qc/clean.py
@@ -476,8 +476,12 @@ class CleanDataset(object):
             return
 
         made_change = False
-        flag_meanings = copy.copy(
-            self._obj[qc_variable].attrs['flag_meanings'])
+        try:
+            flag_meanings = copy.copy(
+                self._obj[qc_variable].attrs['flag_meanings'])
+        except KeyError:
+            return
+
         for attr in test_dict.keys():
             for ii, test in enumerate(flag_meanings):
                 if attr in test:

--- a/act/qc/comparison_tests.py
+++ b/act/qc/comparison_tests.py
@@ -43,6 +43,12 @@ class QCTests:
             calculated time shift is larger than this value will set all
             values in the QC variable to a tripped test value.
 
+        Returns
+        -------
+        test_info : tuple
+            A tuple containing test information including var_name, qc variable name,
+            test_number, test_meaning, test_assessment
+
         """
         # If no comparison variable name given assume matches variable name
         if comp_var_name is None:
@@ -88,5 +94,8 @@ class QCTests:
         meaning = (f"Time shift detected with Minimum Difference test. Comparison of "
                    f"{var_name} with {comp_var_name} off by {time_diff} seconds "
                    f"exceeding absolute threshold of {time_qc_threshold} seconds.")
-        self._obj.qcfilter.add_test(var_name, index=index,
-                                    test_meaning=meaning, test_assessment='Indeterminate')
+        result = self._obj.qcfilter.add_test(var_name, index=index,
+                                             test_meaning=meaning,
+                                             test_assessment='Indeterminate')
+
+        return result

--- a/act/qc/qcfilter.py
+++ b/act/qc/qcfilter.py
@@ -286,6 +286,7 @@ class QCFilter(qctests.QCTests, comparison_tests.QCTests, object):
         test_dict['test_meaning'] = test_meaning
         test_dict['test_assessment'] = test_assessment
         test_dict['qc_variable_name'] = qc_var_name
+        test_dict['variable_name'] = var_name
 
         return test_dict
 
@@ -565,7 +566,7 @@ class QCFilter(qctests.QCTests, comparison_tests.QCTests, object):
         # be retuned from np.zeros as scalar.
         test_mask = np.atleast_1d(test_mask)
         test_mask[tripped] = 1
-        test_mask = np.ma.make_mask(test_mask)
+        test_mask = np.ma.make_mask(test_mask, shrink=False)
 
         if return_index:
             test_mask = np.where(test_mask)[0]

--- a/act/qc/qctests.py
+++ b/act/qc/qctests.py
@@ -70,6 +70,12 @@ class QCTests:
             Optional text to prepend to the test meaning.
             Example is indicate what institution added the test.
 
+        Returns
+        -------
+        test_info : tuple
+            A tuple containing test information including var_name, qc variable name,
+            test_number, test_meaning, test_assessment
+
         """
         if test_meaning is None:
             test_meaning = 'Value is set to missing_value.'
@@ -154,6 +160,12 @@ class QCTests:
             Optional text to prepend to the test meaning.
             Example is indicate what institution added the test.
 
+        Returns
+        -------
+        test_info : tuple
+            A tuple containing test information including var_name, qc variable name,
+            test_number, test_meaning, test_assessment
+
         """
         if limit_value is None:
             return
@@ -233,6 +245,12 @@ class QCTests:
         prepend_text : str
             Optional text to prepend to the test meaning.
             Example is indicate what institution added the test.
+
+        Returns
+        -------
+        test_info : tuple
+            A tuple containing test information including var_name, qc variable name,
+            test_number, test_meaning, test_assessment
 
         """
         if limit_value is None:
@@ -314,6 +332,12 @@ class QCTests:
         prepend_text : str
             Optional text to prepend to the test meaning.
             Example is indicate what institution added the test.
+
+        Returns
+        -------
+        test_info : tuple
+            A tuple containing test information including var_name, qc variable name,
+            test_number, test_meaning, test_assessment
 
         """
         if limit_value is None:
@@ -397,6 +421,12 @@ class QCTests:
             Optional text to prepend to the test meaning.
             Example is indicate what institution added the test.
 
+        Returns
+        -------
+        test_info : tuple
+            A tuple containing test information including var_name, qc variable name,
+            test_number, test_meaning, test_assessment
+
         """
         if limit_value is None:
             return
@@ -477,6 +507,12 @@ class QCTests:
         prepend_text : str
             Optional text to prepend to the test meaning.
             Example is indicate what institution added the test.
+
+        Returns
+        -------
+        test_info : tuple
+            A tuple containing test information including var_name, qc variable name,
+            test_number, test_meaning, test_assessment
 
         """
         if limit_value is None:
@@ -559,6 +595,12 @@ class QCTests:
         prepend_text : str
             Optional text to prepend to the test meaning.
             Example is indicate what institution added the test.
+
+        Returns
+        -------
+        test_info : tuple
+            A tuple containing test information including var_name, qc variable name,
+            test_number, test_meaning, test_assessment
 
         """
         if limit_value is None:
@@ -648,6 +690,12 @@ class QCTests:
         prepend_text : str
             Optional text to prepend to the test meaning.
             Example is indicate what institution added the test.
+
+        Returns
+        -------
+        test_info : tuple
+            A tuple containing test information including var_name, qc variable name,
+            test_number, test_meaning, test_assessment
 
         """
         qc_var_name = self._obj.qcfilter.check_for_ancillary_qc(var_name)
@@ -748,6 +796,12 @@ class QCTests:
             Optional text to prepend to the test meaning.
             Example is indicate what institution added the test.
 
+        Returns
+        -------
+        test_info : tuple
+            A tuple containing test information including var_name, qc variable name,
+            test_number, test_meaning, test_assessment
+
         """
         qc_var_name = self._obj.qcfilter.check_for_ancillary_qc(var_name)
 
@@ -845,6 +899,12 @@ class QCTests:
             Optional text to prepend to the test meaning.
             Example is indicate what institution added the test.
 
+        Returns
+        -------
+        test_info : tuple
+            A tuple containing test information including var_name, qc variable name,
+            test_number, test_meaning, test_assessment
+
         """
         data = self._obj[var_name]
         if window > data.size:
@@ -927,6 +987,12 @@ class QCTests:
         prepend_text : str
             Optional text to prepend to the test meaning.
             Example is indicate what institution added the test.
+
+        Returns
+        -------
+        test_info : tuple
+            A tuple containing test information including var_name, qc variable name,
+            test_number, test_meaning, test_assessment
 
         """
         if not isinstance(dataset2_dict, dict):


### PR DESCRIPTION
In get_qc_test_mask() the returned value is expected to be a numpy masked array. Turns out the default behavior of numpy ma is to not make a ma if all mask values are to be set to False. This is not what we want. Need to set a keyword to force creation of ma even when all mask values are False.

Also updated the returned tuple from setting tests to have the data variable name as one of the members of the tuple. While in there fixed some documentation.