### PR TITLE
ENH: Moving astral to pip install for conda

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,10 +8,12 @@ dependencies:
   - scipy
   - xarray
   - matplotlib
-  - astral
   - dask
   - distributed
   - pandas
   - pint
   - requests
   - pyproj>=2.0.0
+  - pip
+  - pip:
+    - astral>=2.2


### PR DESCRIPTION
Conda has issues with astral that I am trying to work around.