### PR TITLE
Capturing warning about NaNs with comparisons.

### DIFF
--- a/act/qc/radiometer_tests.py
+++ b/act/qc/radiometer_tests.py
@@ -11,6 +11,8 @@ import datetime
 import pandas as pd
 import dask
 import astral
+import warnings
+
 try:
     from astral.sun import sun, elevation, noon
     ASTRAL = True
@@ -175,12 +177,14 @@ def fft_shading_test_process(time, lat, lon, data, shad_freq_lower=None,
     # Set if night or not
     shading = 0
     night = False
-    if sr < ss:
-        if (pd.Timestamp(time) < sr) or (pd.Timestamp(time) > ss):
-            night = True
-    if sr > ss:
-        if (pd.Timestamp(time) < sr) and (pd.Timestamp(time) > ss):
-            night = True
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
+        if sr < ss:
+            if (pd.Timestamp(time) < sr) or (pd.Timestamp(time) > ss):
+                night = True
+        if sr > ss:
+            if (pd.Timestamp(time) < sr) and (pd.Timestamp(time) > ss):
+                night = True
 
     # Return shading of 0 if no valid data or it's night
     if len(data) == 0 or night is True:
@@ -191,7 +195,9 @@ def fft_shading_test_process(time, lat, lon, data, shad_freq_lower=None,
     freq = rfftfreq(fftv.size, d=time_interval)
 
     # Get FFT data under threshold
-    idx = (fftv < 1.)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
+        idx = (fftv < 1.)
     index = np.where(idx)
     fftv = fftv[index]
     freq = freq[index]

--- a/act/qc/radiometer_tests.py
+++ b/act/qc/radiometer_tests.py
@@ -177,14 +177,12 @@ def fft_shading_test_process(time, lat, lon, data, shad_freq_lower=None,
     # Set if night or not
     shading = 0
     night = False
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=RuntimeWarning)
-        if sr < ss:
-            if (pd.Timestamp(time) < sr) or (pd.Timestamp(time) > ss):
-                night = True
-        if sr > ss:
-            if (pd.Timestamp(time) < sr) and (pd.Timestamp(time) > ss):
-                night = True
+    if sr < ss:
+        if (pd.Timestamp(time) < sr) or (pd.Timestamp(time) > ss):
+            night = True
+    if sr > ss:
+        if (pd.Timestamp(time) < sr) and (pd.Timestamp(time) > ss):
+            night = True
 
     # Return shading of 0 if no valid data or it's night
     if len(data) == 0 or night is True:


### PR DESCRIPTION
There is a warning about values in the fftv variable: " RuntimeWarning: invalid value encountered in less idx = (fftv < 1.)". Just adding a warning capture in a with: to suppress the output.