### PR TITLE
ENH: Updates to the FFT radiometer test to allow users to plot up FFT

### DIFF
--- a/act/qc/radiometer_tests.py
+++ b/act/qc/radiometer_tests.py
@@ -169,7 +169,7 @@ def fft_shading_test_process(time, lat, lon, data, shad_freq_lower=None,
     ----------
     time : datetime
         Center time of calculation used for calculating sunrise/sunset
-    lat : floa
+    lat : float
         Latitude used for calculating sunrise/sunset
     lon : float
         Longitude used for calculating sunrise/sunset
@@ -178,12 +178,11 @@ def fft_shading_test_process(time, lat, lon, data, shad_freq_lower=None,
     shad_freq_lower : list
         Lower limits of freqencies to look for shading issues
     shad_freq_upper : list
-        Upperlimits of freqencies to look for shading issues
+        Upper limits of freqencies to look for shading issues
     ratio_thresh : list
         Thresholds to apply, corresponding to frequencies chosen
     time_interval : float
         Time interval of data
-
 
     Returns
     -------


### PR DESCRIPTION
Adds the FFT and frequency data to the object so that users can plot up the data like so:

`  
# Set up plot information
    nrows = 6 
    ncols = 4
    x = 0
    y = 0
    fig, ax = plt.subplots(nrows, ncols, figsize=(15,10))
    sdate = pd.to_datetime(obj['time'].values[0])
    # Get upper and lower frequencies to look for shading
    upper = obj['fft'].attrs['upper_freq']
    lower = obj['fft'].attrs['lower_freq']
    #Plots data up in hourly increments
    for i in range(24):
        dummy = obj.sel({'time': slice(sdate.replace(hour=i, minute=0, second=0),
                                       sdate.replace(hour=i, minute=0, second=0) +
                                       pd.Timedelta(1,'hours'))})

        # Shades the background of where to look for spikes
        # Plots FFT if available
        ax[x,y].set_xlim([np.nanmin(obj['fft_freq']), np.nanmax(obj['fft_freq'])])
        ax[x, y].axvspan(lower[0], upper[0], color='red', alpha=0.25)
        ax[x, y].axvspan(lower[1], upper[1], color='red', alpha=0.25)
        ax[x, y].set_title(str(i).zfill(2) + '00')
        if len(dummy['time'].values) > 1:
            ax[x, y].plot(np.transpose(dummy['fft_freq'].values), np.transpose(dummy['fft'].values),
                         'k', linestyle='solid')
        y += 1
        if y == ncols:
            y = 0
            x += 1
    plt.tight_layout()
    plt.show()`