### PR TITLE
Numpy float 

### DIFF
--- a/act/plotting/timeseriesdisplay.py
+++ b/act/plotting/timeseriesdisplay.py
@@ -517,18 +517,19 @@ class TimeSeriesDisplay(Display):
             else:
                 our_data = ydata
 
-            if np.isfinite(our_data).any():
+            finite = np.isfinite(our_data)
+            if finite.any():
+                our_data = our_data[finite]
                 if invert_y_axis is False:
-                    yrng = [np.nanmin(our_data), np.nanmax(our_data)]
+                    yrng = [np.min(our_data), np.max(our_data)]
                 else:
-                    yrng = [np.nanmax(our_data), np.nanmin(our_data)]
+                    yrng = [np.max(our_data), np.min(our_data)]
             else:
                 yrng = [0, 1]
 
             # Check if current range is outside of new range an only set
             # values that work for all data plotted.
             current_yrng = ax.get_ylim()
-
             if yrng[0] > current_yrng[0]:
                 yrng[0] = current_yrng[0]
             if yrng[1] < current_yrng[1]:

--- a/act/qc/qcfilter.py
+++ b/act/qc/qcfilter.py
@@ -710,6 +710,10 @@ class QCFilter(qctests.QCTests, comparison_tests.QCTests, object):
 
         # Create mask of indexes by looking where each test is set
         variable = self._obj[var_name].values
+        nan_dtype = np.float32
+        if variable.dtype in (np.float64, np.int64):
+            nan_dtype = np.float64
+
         mask = np.zeros(variable.shape, dtype=bool)
         for test in test_numbers:
             mask = mask | self._obj.qcfilter.get_qc_test_mask(
@@ -734,7 +738,7 @@ class QCFilter(qctests.QCTests, comparison_tests.QCTests, object):
 
         # If asked to return numpy array with values set to NaN
         if return_nan_array:
-            variable = variable.astype(np.float)
+            variable = variable.astype(nan_dtype)
             variable = variable.filled(fill_value=np.nan)
 
         return variable


### PR DESCRIPTION
Numpy has updated the way to set data type and there is currently a warning for one last place we use the old format. This fixes that warning. Also, fixing issue setting yrange on plots when there are inf values.