### PR TITLE
Use coords when adding new DataArray

### DIFF
--- a/act/qc/qcfilter.py
+++ b/act/qc/qcfilter.py
@@ -163,7 +163,7 @@ class QCFilter(qctests.QCTests, comparison_tests.QCTests, object):
             qc_data = np.zeros_like(self._obj[var_name].values, dtype=np.int32)
 
         self._obj[qc_var_name] = xr.DataArray(
-            data=qc_data, dims=self._obj[var_name].dims,
+            data=qc_data, coords=self._obj[var_name].coords,
             attrs={"long_name": qc_variable_long_name,
                    "units": '1'}
         )

--- a/act/qc/qcfilter.py
+++ b/act/qc/qcfilter.py
@@ -162,6 +162,8 @@ class QCFilter(qctests.QCTests, comparison_tests.QCTests, object):
         except AttributeError:
             qc_data = np.zeros_like(self._obj[var_name].values, dtype=np.int32)
 
+        # Updating to use coords instead of dim, which caused a loss of
+        # attribuets as noted in Issue 347
         self._obj[qc_var_name] = xr.DataArray(
             data=qc_data, coords=self._obj[var_name].coords,
             attrs={"long_name": qc_variable_long_name,


### PR DESCRIPTION
This fixes #347 by using `coords` instead of `dims` in the construction of a new `DataArray` added to `self._obj`.