### PR TITLE
ENH: There's a but in that open_mfdataset defaults to open_dataset if…

### DIFF
--- a/act/io/armfiles.py
+++ b/act/io/armfiles.py
@@ -74,10 +74,11 @@ def read_netcdf(filenames, concat_dim=None, return_None=False,
     file_times = []
 
     # Add funciton keywords to kwargs dictionary for passing into open_mfdataset.
-    kwargs['combine'] = combine
-    kwargs['concat_dim'] = concat_dim
-    kwargs['use_cftime'] = use_cftime
-    kwargs['combine_attrs'] = combine_attrs
+    if len(filenames) > 1:
+        kwargs['combine'] = combine
+        kwargs['concat_dim'] = concat_dim
+        kwargs['use_cftime'] = use_cftime
+        kwargs['combine_attrs'] = combine_attrs
 
     # Create an exception tuple to use with try statements. Doing it this way
     # so we can add the FileNotFoundError if requested. Can add more error


### PR DESCRIPTION
… it's one file.  Putting in a check so open_mfdataset keywords aren't passed to open_dataset