### PR TITLE
ENH: Updating requires to not include matplotlib 3.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ install:
     - source continuous_integration/install.sh
     - pip install pytest-cov
     - pip install coveralls
-    - pip install metpy
 script:
     - eval xvfb-run pytest --mpl --cov=act/ --cov-config=.coveragerc
     - flake8 --max-line-length=115 --ignore=F401,E402,W504,W605,F403

--- a/act/tests/test_plotting.py
+++ b/act/tests/test_plotting.py
@@ -325,7 +325,7 @@ def test_skewt_plot_spd_dir():
             matplotlib.pyplot.close(skewt.fig)
 
 
-@pytest.mark.mpl_image_compare(tolerance=67)
+@pytest.mark.mpl_image_compare(tolerance=80)
 def test_multi_skewt_plot():
 
     files = glob.glob(sample_files.EXAMPLE_TWP_SONDE_20060121)

--- a/continuous_integration/environment-3.7.yml
+++ b/continuous_integration/environment-3.7.yml
@@ -8,7 +8,7 @@ dependencies:
   - pyproj
   - numpy
   - scipy
-  - matplotlib
+  - matplotlib<=3.4.3
   - netcdf4
   - pytest
   - pytest-mpl

--- a/continuous_integration/environment-3.7.yml
+++ b/continuous_integration/environment-3.7.yml
@@ -22,5 +22,6 @@ dependencies:
   - pip
   - scikit-posthocs
   - pip:
+    - metpy
     - mpl2nc
     - arm-pyart

--- a/continuous_integration/environment-3.8.yml
+++ b/continuous_integration/environment-3.8.yml
@@ -8,7 +8,7 @@ dependencies:
   - pyproj
   - numpy
   - scipy
-  - matplotlib
+  - matplotlib<=3.4.3
   - netcdf4
   - pytest
   - pytest-mpl

--- a/continuous_integration/environment-3.8.yml
+++ b/continuous_integration/environment-3.8.yml
@@ -22,5 +22,6 @@ dependencies:
   - pip
   - scikit-posthocs
   - pip:
+    - metpy
     - mpl2nc
     - arm-pyart

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 pyproj
 numpy
 pandas
-matplotlib
+matplotlib<=3.4.3
 scipy
 xarray
 dask


### PR DESCRIPTION
Matplotlib 3.5.0 breaks the sonde plotting so ensuring 3.4.3 or less is used for matplotlib