### PR TITLE
QC processing time

### DIFF
--- a/act/qc/qcfilter.py
+++ b/act/qc/qcfilter.py
@@ -26,7 +26,7 @@ class QCFilter(qctests.QCTests, comparison_tests.QCTests, object):
         self._obj = xarray_obj
 
     def check_for_ancillary_qc(self, var_name, add_if_missing=True,
-                               cleanup=True, flag_type=False):
+                               cleanup=False, flag_type=False):
         """
         Method to check if a quality control variable exist in the dataset
         and return the quality control varible name.
@@ -92,8 +92,7 @@ class QCFilter(qctests.QCTests, comparison_tests.QCTests, object):
             self._obj.qcfilter.update_ancillary_variable(var_name, qc_var_name)
 
         # Clean up quality control variables to the requried standard in the
-        # xarray object. If the quality control variables are already cleaned
-        # the extra work is small since it's just checking.
+        # xarray object.
         if cleanup:
             self._obj.clean.cleanup(handle_missing_value=True,
                                     link_qc_variables=False)

--- a/act/tests/test_qc.py
+++ b/act/tests/test_qc.py
@@ -7,7 +7,10 @@ from act.qc.qcfilter import parse_bit, set_bit, unset_bit
 import numpy as np
 import pytest
 import copy
+import pandas as pd
 import dask.array as da
+import xarray as xr
+from datetime import datetime
 
 
 def test_fft_shading_test():
@@ -787,3 +790,32 @@ def test_qc_data_type():
     assert ds_object[expected_qc_var_name].attrs['flag_masks'][0].dtype == np.uint64
 
     ds_object.qcfilter.add_test(var_name, index=[1], test_meaning='Fourth test', recycle=True)
+
+
+def test_qc_speed():
+    """
+    This tests the speed of the QC module to ensure changes do not significantly
+    slow down the module's processing.
+    """
+
+    n_variables = 100
+    n_samples = 100
+
+    time = pd.date_range(start="2022-02-17 00:00:00", end="2022-02-18 00:00:00", periods=n_samples)
+
+    # Create data variables with random noise
+    np.random.seed(42)
+    noisy_data_mapping = {f"data_var_{i}": np.random.random(time.shape) for i in range(n_variables)}
+
+    ds = xr.Dataset(
+        data_vars={name: ("time", data) for name, data in noisy_data_mapping.items()},
+        coords={"time": time},
+    )
+
+    start = datetime.utcnow()
+    for name, var in noisy_data_mapping.items():
+        failed_qc = var > 0.75  # Consider data above 0.75 as bad. Negligible time here.
+        ds.qcfilter.add_test(name, index=failed_qc, test_meaning="Value above threshold")
+
+    time_diff = datetime.utcnow() - start
+    assert time_diff.seconds <= 2

--- a/act/tests/test_qc.py
+++ b/act/tests/test_qc.py
@@ -818,4 +818,4 @@ def test_qc_speed():
         ds.qcfilter.add_test(name, index=failed_qc, test_meaning="Value above threshold")
 
     time_diff = datetime.utcnow() - start
-    assert time_diff.seconds <= 2
+    assert time_diff.seconds <= 3


### PR DESCRIPTION
Issue #391 pointed out a performance issue with setting a new QC test. Turns out there was a call to .clean.cleanup() in the add_test() method via check_for_ancillary_qc() that was unnecessary and causing a significant number of loops to be executed. The default has been changed so clean.cleanup() is not run. Also, updated the way the QC variable names are extracted from the object to be more efficient and more accurate.

To ensure this type of thing does not happen again with a change to the QC code, I've added a test of the performance of the add_test() method. It uses wall clock time so it's not the best methodology, but should highlight significant performance decreases.

Overall this is a significant performance boost with a 60 fold decrease in computation time.