### PR TITLE
Add Google Analytics ID

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -126,7 +126,9 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    'google_analytics_id': 'UA-179020619-3',
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
Add a Google Analytics ID to the `conf.py` file used by sphinx. For those interested in having access the analytics, you will need to send over your gmail address

Fixes #396 