### PR TITLE
Fix Google Analytics to Match RTD Theme

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -127,7 +127,7 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # documentation.
 #
 html_theme_options = {
-    'google_analytics_id': 'UA-179020619-3',
+    'analytics_id': 'UA-179020619-3',
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
Looks like I spoke too soon - within the read the docs theme, [they mention how to add the ID](https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html?highlight=analytics#confval-analytics_id), which is different from the PyData theme I used before... the main change being `analytics_id` instead of `google_analytics_id`