### PR TITLE
Not setting keywords for open_mfdataset() call

### DIFF
--- a/act/io/armfiles.py
+++ b/act/io/armfiles.py
@@ -74,11 +74,10 @@ def read_netcdf(filenames, concat_dim=None, return_None=False,
     file_times = []
 
     # Add funciton keywords to kwargs dictionary for passing into open_mfdataset.
-    if len(filenames) > 1:
-        kwargs['combine'] = combine
-        kwargs['concat_dim'] = concat_dim
-        kwargs['use_cftime'] = use_cftime
-        kwargs['combine_attrs'] = combine_attrs
+    kwargs['combine'] = combine
+    kwargs['concat_dim'] = concat_dim
+    kwargs['use_cftime'] = use_cftime
+    kwargs['combine_attrs'] = combine_attrs
 
     # Create an exception tuple to use with try statements. Doing it this way
     # so we can add the FileNotFoundError if requested. Can add more error


### PR DESCRIPTION
Turns out there was an unnecessary check on filename list length that was assuming filename was a list. This resulted in excluding single value lists from setting the kwargs values. We need to set these to ensure using use_cftime keyword is used.