### PR TITLE
Rename Master to Main

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,10 +3,10 @@ name: build-docs
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 # This job installs dependencies, build the website, and pushes it to `gh-pages`
 jobs:

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -2,9 +2,9 @@ name: Python Package using Conda
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
Ensure that the doc/ci workflows utilize the `main` branch instead of `master`