### PR TITLE
ADD: Adding coveralls back in, updating pytest and flake8 as well

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -10,6 +10,7 @@ env:
   ARM_USERNAME: ${{ secrets.ARM_USERNAME }}
   ARM_PASSWORD: ${{ secrets.ARM_PASSWORD }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  COVERALLS_TOKEN: ${{ secrets.COVERLALLS_REPO_TOKEN }}
 
 jobs:
   build:
@@ -64,4 +65,5 @@ jobs:
           conda install pytest-mpl
           conda install coveralls
           pytest --mpl --cov=act/ --cov-config=.coveragerc
-          coveralls
+          #COVERALLS_REPO_TOKEN=COVERALLS_TOKEN coveralls
+          coveralls --service=github

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -60,6 +60,7 @@ jobs:
         run: |
           conda install pytest
           conda install pytest-cov
+          conda install pytest-mpl
           pytest --mpl --cov=act/ --cov-config=.coveragerc
       - name: Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -65,4 +65,4 @@ jobs:
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:
-          github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -61,8 +61,6 @@ jobs:
           conda install pytest
           conda install pytest-cov
           conda install pytest-mpl
+          conda install coveralls
           pytest --mpl --cov=act/ --cov-config=.coveragerc
-      - name: Coveralls
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          coveralls

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -51,11 +51,17 @@ jobs:
         run: |
           conda install flake8
           # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          #flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-
+          #flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          # Switching back to original flake
+          flake8 --max-line-length=127 --ignore=F401,E402,W504,W605,F403
       - name: Test with pytest
         run: |
           conda install pytest
-          pytest -v
+          conda install pytest-cov
+          pytest --mpl --cov=act/ --cov-config=.coveragerc
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -63,7 +63,9 @@ jobs:
           conda install pytest
           conda install pytest-cov
           conda install pytest-mpl
-          conda install coveralls
           pytest --mpl --cov=act/ --cov-config=.coveragerc
-          #COVERALLS_REPO_TOKEN=COVERALLS_TOKEN coveralls
+
+      - name: Submit results to coveralls
+        run: |
+          conda install coveralls
           coveralls --service=github

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -9,6 +9,7 @@ on:
 env:
   ARM_USERNAME: ${{ secrets.ARM_USERNAME }}
   ARM_PASSWORD: ${{ secrets.ARM_PASSWORD }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   build:

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Atmospheric data Community Toolkit (ACT)
 .. |Build| image:: https://github.com/ARM-DOE/ACT/actions/workflows/python-package-conda.yml/badge.svg
     :target: https://github.com/ARM-DOE/ACT/actions/workflows/python-package-conda_linux.yml
 
-The Atmospheric data Community Toolkit (ACT) is an open source Python toolkit for working with atmospheric time-series datasets of varying dimensions.  The toolkit has functions for every part of the scientific process; discovery, IO, quality control, corrections, retrievals, visualization, and analysis.   It is a community platform for sharing code with the goal of reducing duplication of effort and better connecting the science community with programs such as the `Atmospheric Radiation Measurement (ARM) User Facility <http://www.arm.gov>`_.  Overarching development goals will be updated on a regular basis as part of the `Roadmap <https://github.com/AdamTheisen/ACT/blob/master/guides/ACT_Roadmap.pdf>`_  .
+The Atmospheric data Community Toolkit (ACT) is an open source Python toolkit for working with atmospheric time-series datasets of varying dimensions.  The toolkit has functions for every part of the scientific process; discovery, IO, quality control, corrections, retrievals, visualization, and analysis.   It is a community platform for sharing code with the goal of reducing duplication of effort and better connecting the science community with programs such as the `Atmospheric Radiation Measurement (ARM) User Facility <http://www.arm.gov>`_.  Overarching development goals will be updated on a regular basis as part of the `Roadmap <https://github.com/AdamTheisen/ACT/blob/master/guides/ACT_Roadmap_2.pdf>`_  .
 
 |act|
 


### PR DESCRIPTION
Pytest and flake8 requirements were updated with the switch to github actions which is causing us to miss a few things I think on PRs.  Trying to bring back to original standards.