### PR TITLE
Pin MetPy version

### DIFF
--- a/docs/environment_docs.yml
+++ b/docs/environment_docs.yml
@@ -18,7 +18,7 @@ dependencies:
   - pip
   - pip:
     - mpl2nc
-    - metpy
+    - metpy>=1.2
     - arm-pyart
     - sphinx
     - sphinx_gallery


### PR DESCRIPTION
For the environment docs, make sure to use MetPy version >=1.2