### PR TITLE
Adding keep_variables to reader

### DIFF
--- a/act/config.py
+++ b/act/config.py
@@ -1,0 +1,13 @@
+"""
+Configuration file for the Python Atmospheric data Community Toolkit (ACT)
+The values for a number of ACT parameters and the default metadata created
+when reading files, correcting fields, etc. is controlled by this single
+Python configuration file.
+
+Examples:
+---------
+from act.config import DEFAULT_DATASTREAM_NAME
+
+"""
+
+DEFAULT_DATASTREAM_NAME = 'act_datastream'

--- a/act/io/armfiles.py
+++ b/act/io/armfiles.py
@@ -17,6 +17,7 @@ import numpy as np
 import xarray as xr
 
 import act.utils as utils
+from act.config import DEFAULT_DATASTREAM_NAME
 
 
 def read_netcdf(
@@ -257,7 +258,7 @@ def read_netcdf(
     # Ensure that we have _datastream set whether or no there's
     # a datastream attribute already.
     if is_arm_file_flag == 0:
-        ds.attrs['_datastream'] = 'act_datastream'
+        ds.attrs['_datastream'] = DEFAULT_DATASTREAM_NAME
     else:
         ds.attrs['_datastream'] = ds.attrs['datastream']
 
@@ -375,6 +376,14 @@ def check_arm_standards(ds):
     the_flag = 1 << 0
     if 'datastream' not in ds.attrs.keys():
         the_flag = 0
+
+    # Check if the historical global attribute name is
+    # used instead of updated name of 'datastream'. If so
+    # correct the global attributes and flip flag.
+    if 'zeb_platform' in ds.attrs.keys():
+        ds.attrs['datastream'] = copy.copy(ds.attrs['zeb_platform'])
+        del ds.attrs['zeb_platform']
+        the_flag = 1 << 0
 
     return the_flag
 

--- a/act/io/armfiles.py
+++ b/act/io/armfiles.py
@@ -274,13 +274,14 @@ def keep_variables_to_drop_variables(
         keep_variables,
         drop_variables=None):
     """
-    Returns a list of variable names to use with drop_variables when calling
-    `Xarray.open_dataset` by giving a list of variables to keep. This can
-    greatly help reduce loading time and disk space of the Dataset.
+    Returns a list of variable names to exclude from reading by passing into
+    `Xarray.open_dataset` drop_variables keyword. This can greatly help reduce
+    loading time and disk space use of the Dataset.
 
-    Will open the netCDF file with netCDF4 library to get list of variable
-    names. If more than one filename is provided or string is a regular
-    expression, will use the first file in the list.
+    When passed a netCDF file name, will open the file using the netCDF4 library to get
+    list of variable names. There is less overhead reading the varible names using
+    netCDF4 library than Xarray. If more than one filename is provided or string is
+    used for shell syntax globbing, will use the first file in the list.
 
     Parameters
     ----------
@@ -288,28 +289,26 @@ def keep_variables_to_drop_variables(
         Name of file(s) to read.
     keep_variables : str or list of str
         Variable names desired to keep. Do not need to list associated dimention
-        names. These will be automatically excluded as well from the returned list.
+        names. These will be automatically kept as well.
     drop_variables : str or list of str
         Variable names to explicitly add to returned list. May be helpful if a variable
         exists in a file that is not in the first file in the list.
 
     Returns
     -------
-    act_obj : list of srt
-        Variable names to use with drop_variables that will not be read when calling
-        .open_dataset().
+    act_obj : list of str
+        Variable names to exclude from returned Dataset by using drop_variables keyword
+        when calling Xarray.open_dataset().
 
     Examples
     --------
-    This example will load the example sounding data used for unit testing.
-
     .. code-block :: python
 
         import act
         filename = '/data/datastream/hou/houkasacrcfrM1.a1/houkasacrcfrM1.a1.20220404.*.nc'
         drop_vars = act.io.armfiles.keep_variables_to_drop_variables(
             filename, ['lat','lon','alt','crosspolar_differential_phase'],
-            drop_variables='some_crazy_variable_name')
+            drop_variables='variable_name_that_only_exists_in_last_file_of_the_day')
 
     """
     read_variables = []

--- a/act/qc/arm.py
+++ b/act/qc/arm.py
@@ -5,9 +5,10 @@ the Atmospheric Radiation Measurement Program (ARM).
 """
 
 import datetime as dt
-
 import numpy as np
 import requests
+
+from act.config import DEFAULT_DATASTREAM_NAME
 
 
 def add_dqr_to_qc(
@@ -60,6 +61,10 @@ def add_dqr_to_qc(
         datastream = obj.attrs['_datastream']
     else:
         raise ValueError('Object does not have datastream attribute')
+
+    if datastream == DEFAULT_DATASTREAM_NAME:
+        raise ValueError("'datastream' name required for DQR service set to default value "
+                         f"{datastream}. Unable to perform DQR service query.")
 
     # Clean up QC to conform to CF conventions
     obj.clean.cleanup()

--- a/act/tests/test_io.py
+++ b/act/tests/test_io.py
@@ -32,6 +32,48 @@ def test_io():
     sonde_ds.close()
 
 
+def test_keep_variables():
+
+    var_names = ['temp_mean', 'rh_mean', 'wdir_vec_mean', 'tbrg_precip_total_corr',
+                 'atmos_pressure', 'wspd_vec_mean', 'pwd_pw_code_inst', 'pwd_pw_code_15min',
+                 'pwd_mean_vis_10min', 'logger_temp', 'pwd_precip_rate_mean_1min',
+                 'pwd_cumul_snow', 'pwd_mean_vis_1min', 'pwd_pw_code_1hr', 'org_precip_rate_mean',
+                 'tbrg_precip_total', 'pwd_cumul_rain']
+    var_names = var_names + ['qc_' + ii for ii in var_names]
+    drop_variables = act.io.armfiles.keep_variables_to_drop_variables(
+        act.tests.EXAMPLE_MET1, var_names)
+
+    expected_drop_variables = [
+        'wdir_vec_std', 'base_time', 'alt', 'qc_wspd_arith_mean', 'pwd_err_code', 'logger_volt',
+        'temp_std', 'lon', 'qc_logger_volt', 'time_offset', 'wspd_arith_mean', 'lat', 'vapor_pressure_std',
+        'vapor_pressure_mean', 'rh_std', 'qc_vapor_pressure_mean']
+    assert drop_variables.sort() == expected_drop_variables.sort()
+
+    ds_object = act.io.armfiles.read_netcdf(act.tests.EXAMPLE_MET1, keep_variables='temp_mean')
+    assert list(ds_object.data_vars) == ['temp_mean']
+    del ds_object
+
+    var_names = ['temp_mean', 'qc_temp_mean']
+    ds_object = act.io.armfiles.read_netcdf(act.tests.EXAMPLE_MET1, keep_variables=var_names,
+                                            drop_variables='nonsense')
+    assert list(ds_object.data_vars).sort() == var_names.sort()
+    del ds_object
+
+    var_names = ['temp_mean', 'qc_temp_mean', 'alt', 'lat', 'lon']
+    ds_object = act.io.armfiles.read_netcdf(act.tests.EXAMPLE_MET_WILDCARD, keep_variables=var_names,
+                                            drop_variables=['lon'])
+    var_names = list(set(var_names) - set(['lon']))
+    assert list(ds_object.data_vars).sort() == var_names.sort()
+    del ds_object
+
+    filenames = Path(act.tests.EXAMPLE_MET_WILDCARD).parent
+    filenames = list(filenames.glob(Path(act.tests.EXAMPLE_MET_WILDCARD).name))
+    var_names = ['temp_mean', 'qc_temp_mean', 'alt', 'lat', 'lon']
+    ds_object = act.io.armfiles.read_netcdf(filenames, keep_variables=var_names)
+    assert list(ds_object.data_vars).sort() == var_names.sort()
+    del ds_object
+
+
 def test_io_mfdataset():
     met_ds = act.io.armfiles.read_netcdf(act.tests.EXAMPLE_MET_WILDCARD)
     met_ds.load()


### PR DESCRIPTION
The reader allows the use of drop_variables to not read in variables
but this requires the knowledge of the variable names to drop. This
feature allows for setting the variables to keep and it will figure the
names of the variables to add to drop_variables to not read in.

Part of #431 