### PR TITLE
FIX: Fix failing ci by adding missing % to ARMLive

### DIFF
--- a/act/discovery/get_armfiles.py
+++ b/act/discovery/get_armfiles.py
@@ -96,10 +96,10 @@ def download_data(username, token, datastream, startdate, enddate, time=None, ou
     # start and end strings for query_url are constructed
     # if the arguments were provided
     if startdate:
-        start = date_parser(startdate, output_format='%Y-%m-%dT%H:%M:%S.f')[:-3] + 'Z'
+        start = date_parser(startdate, output_format='%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
         start = f'&start={startdate}'
     if enddate:
-        end = date_parser(enddate, output_format='%Y-%m-%dT%H:%M:%SZ.f')[:-3] + 'Z'
+        end = date_parser(enddate, output_format='%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
         end = f'&end={enddate}'
     # build the url to query the web service using the arguments provided
     query_url = (

--- a/act/tests/test_utils.py
+++ b/act/tests/test_utils.py
@@ -616,3 +616,6 @@ def test_date_parser_minute_second():
     date_string = '2020-01-01T12:00:00'
     parsed_date = act.utils.date_parser(date_string, return_datetime=True)
     assert parsed_date == datetime(2020, 1, 1, 12, 0, 0)
+
+    output_format = parsed_date.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
+    assert output_format == '2020-01-01T12:00:00.000Z'


### PR DESCRIPTION
Fix the failing CI caused by a missing % sign in the strftime call in the ARMLive url building