### PR TITLE
FIX: Add barely less than a day for same time

### DIFF
--- a/act/discovery/get_armfiles.py
+++ b/act/discovery/get_armfiles.py
@@ -104,7 +104,7 @@ def download_data(username, token, datastream, startdate, enddate, time=None, ou
         end_datetime = date_parser(enddate, return_datetime=True)
         # If the start and end date are the same, and a day to the end date
         if start_datetime == end_datetime:
-            end_datetime += timedelta(days=1)
+            end_datetime += timedelta(hours=23, minutes=59, seconds=59)
         end = end_datetime.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
         end = f'&end={end}'
     # build the url to query the web service using the arguments provided


### PR DESCRIPTION
Currently, we add a single day when start date == end date for the ARM data discovery. This uses a delta of 23 hours, 59 minutes, and 59 seconds, which will restrict the search to a single day.