### PR TITLE
ENH: Remove Python 3.6 tests, add 3.10 tests

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [macOS, ubuntu, Windows]
         inlcude:
           - os: macos-latest
@@ -74,44 +74,3 @@ jobs:
       - name: Submit results to coveralls
         run: |
           python -m coveralls --service=github
-
-  # Used for testing for ADC systems.
-  old-build:
-    name: ${{ matrix.os }}-${{ matrix.python-version }}
-    if: github.repository == 'ARM-DOE/ACT'
-    runs-on: ${{ matrix.os }}-latest
-    defaults:
-      run:
-        shell: bash -l {0}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.6"]
-        os: [ubuntu]
-        inlcude:
-          - os: ubuntu-latest
-            PLAT: arm64
-            INTERFACE64: ""
-            platform: [x64]
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-          environment-file: ./continuous_integration/environment_actions.yml
-          activate-environment: act_env
-          auto-activate-base: False
-          mamba-version: '*'
-          use-mamba: true
-          miniforge-variant: Mambaforge
-
-      - name: Install ACT
-        run: |
-          python -m pip install -e . --no-deps --force-reinstall
-
-      - name: Test with pytest
-        run: |
-          python -m pytest --mpl --cov=act/ --cov-config=.coveragerc


### PR DESCRIPTION
Upgrade the versions we support, and remove Python 3.6 tests