### PR TITLE
Setting time_xrng with datetime values

### DIFF
--- a/act/plotting/timeseriesdisplay.py
+++ b/act/plotting/timeseriesdisplay.py
@@ -219,6 +219,10 @@ class TimeSeriesDisplay(Display):
         if isinstance(xrng[0], pd.Timestamp):
             xrng = [x.to_numpy() for x in xrng if isinstance(x, pd.Timestamp)]
 
+        # Make sure that the xrng value is a numpy array not datetime.datetime
+        if isinstance(xrng[0], dt.datetime):
+            xrng = [np.datetime64(x) for x in xrng if isinstance(x, dt.datetime)]
+
         if len(subplot_index) < 2:
             self.xrng[subplot_index, 0] = xrng[0].astype('datetime64[D]').astype(float)
             self.xrng[subplot_index, 1] = xrng[1].astype('datetime64[D]').astype(float)

--- a/act/tests/test_plotting.py
+++ b/act/tests/test_plotting.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+from datetime import datetime
 
 import act
 import act.io.armfiles as arm
@@ -1115,3 +1116,19 @@ def test_timeseries_invert():
     display.plot('inst_sfc_ir_temp', invert_y_axis=True)
     ds_object.close()
     return display.fig
+
+
+def test_plot_time_rng():
+    # Test if setting the xrange can be done with pandas or datetime datatype
+    # eventhough the data is numpy. Check for correctly converting xrange values
+    # before setting and not causing an exception.
+    met = arm.read_netcdf(sample_files.EXAMPLE_MET1)
+
+    # Plot data
+    xrng = [datetime(2019, 1, 1, 0, 0), datetime(2019, 1, 2, 0, 0)]
+    display = TimeSeriesDisplay(met)
+    display.plot('temp_mean', time_rng=xrng)
+
+    xrng = [pd.to_datetime('2019-01-01'), pd.to_datetime('2019-01-02')]
+    display = TimeSeriesDisplay(met)
+    display.plot('temp_mean', time_rng=xrng)


### PR DESCRIPTION
Previously we could set the plot() method keyword time_xrng with a list of datetime.datetime values. PR #534 changed the logic to not allow datetime.datetime values. This PR adds a check to convert values just like the Pandas check. This PR resolves issue #557 .