### PR TITLE
TST: Updating test suite for pytest skip if for metpy.

### DIFF
--- a/act/tests/test_plotting.py
+++ b/act/tests/test_plotting.py
@@ -307,34 +307,33 @@ def test_barb_sounding_plot():
         matplotlib.pyplot.close(BarbDisplay.fig)
 
 
+@pytest.mark.skipif(not METPY, reason="Metpy is not installed.")
 @pytest.mark.mpl_image_compare(tolerance=30)
 def test_skewt_plot():
     sonde_ds = arm.read_netcdf(sample_files.EXAMPLE_SONDE1)
-
-    if METPY:
-        skewt = SkewTDisplay(sonde_ds)
-        skewt.plot_from_u_and_v('u_wind', 'v_wind', 'pres', 'tdry', 'dp')
-        sonde_ds.close()
-        try:
-            return skewt.fig
-        finally:
-            matplotlib.pyplot.close(skewt.fig)
+    skewt = SkewTDisplay(sonde_ds)
+    skewt.plot_from_u_and_v('u_wind', 'v_wind', 'pres', 'tdry', 'dp')
+    sonde_ds.close()
+    try:
+        return skewt.fig
+    finally:
+        matplotlib.pyplot.close(skewt.fig)
 
 
+@pytest.mark.skipif(not METPY, reason="Metpy is not installed.")
 @pytest.mark.mpl_image_compare(tolerance=30)
 def test_skewt_plot_spd_dir():
     sonde_ds = arm.read_netcdf(sample_files.EXAMPLE_SONDE1)
-
-    if METPY:
-        skewt = SkewTDisplay(sonde_ds, ds_name='act_datastream')
-        skewt.plot_from_spd_and_dir('wspd', 'deg', 'pres', 'tdry', 'dp')
-        sonde_ds.close()
-        try:
-            return skewt.fig
-        finally:
-            matplotlib.pyplot.close(skewt.fig)
+    skewt = SkewTDisplay(sonde_ds, ds_name='act_datastream')
+    skewt.plot_from_spd_and_dir('wspd', 'deg', 'pres', 'tdry', 'dp')
+    sonde_ds.close()
+    try:
+        return skewt.fig
+    finally:
+        matplotlib.pyplot.close(skewt.fig)
 
 
+@pytest.mark.skipif(not METPY, reason="Metpy is not installed.")
 @pytest.mark.mpl_image_compare(tolerance=80)
 def test_multi_skewt_plot():
 
@@ -346,31 +345,30 @@ def test_multi_skewt_plot():
         sonde_ds = sonde_ds.resample(time='30s').nearest()
         test.update({time: sonde_ds})
 
-    if METPY:
-        skewt = SkewTDisplay(test, subplot_shape=(2, 2))
-        i = 0
-        j = 0
-        for f in files:
-            time = f.split('.')[-3]
-            skewt.plot_from_spd_and_dir(
-                'wspd',
-                'deg',
-                'pres',
-                'tdry',
-                'dp',
-                subplot_index=(j, i),
-                dsname=time,
-                p_levels_to_plot=np.arange(10.0, 1000.0, 25),
-            )
-            if j == 1:
-                i += 1
-                j = 0
-            elif j == 0:
-                j += 1
-        try:
-            return skewt.fig
-        finally:
-            matplotlib.pyplot.close(skewt.fig)
+    skewt = SkewTDisplay(test, subplot_shape=(2, 2))
+    i = 0
+    j = 0
+    for f in files:
+        time = f.split('.')[-3]
+        skewt.plot_from_spd_and_dir(
+            'wspd',
+            'deg',
+            'pres',
+            'tdry',
+            'dp',
+            subplot_index=(j, i),
+            dsname=time,
+            p_levels_to_plot=np.arange(10.0, 1000.0, 25),
+        )
+        if j == 1:
+            i += 1
+            j = 0
+        elif j == 0:
+            j += 1
+    try:
+        return skewt.fig
+    finally:
+        matplotlib.pyplot.close(skewt.fig)
 
 
 @pytest.mark.mpl_image_compare(tolerance=31)

--- a/act/tests/test_retrievals.py
+++ b/act/tests/test_retrievals.py
@@ -13,60 +13,54 @@ try:
 except ImportError:
     PYSP2_AVAILABLE = False
 
+try:
+    import metpy
+    METPY_AVAILABLE = True
+except ImportError:
+    METPY_AVAILABLE = False
 
+
+@pytest.mark.skipif(not METPY_AVAILABLE, reason="Metpy is not installed")
 def test_get_stability_indices():
     sonde_ds = act.io.armfiles.read_netcdf(act.tests.sample_files.EXAMPLE_SONDE1)
+    sonde_ds = act.retrievals.calculate_stability_indicies(
+        sonde_ds, temp_name='tdry', td_name='dp', p_name='pres', rh_name='rh')
+    np.testing.assert_allclose(
+        sonde_ds['parcel_temperature'].values[0:5],
+        [269.85, 269.745276, 269.678006, 269.622444, 269.572331],
+        rtol=1e-5)
+    assert sonde_ds['parcel_temperature'].attrs['units'] == 'kelvin'
+    np.testing.assert_almost_equal(sonde_ds['surface_based_cape'], 0.62, decimal=2)
+    assert sonde_ds['surface_based_cape'].attrs['units'] == 'J/kg'
+    assert sonde_ds['surface_based_cape'].attrs['long_name'] == 'Surface-based CAPE'
+    np.testing.assert_almost_equal(sonde_ds['surface_based_cin'], 0.000, decimal=3)
+    assert sonde_ds['surface_based_cin'].attrs['units'] == 'J/kg'
+    assert sonde_ds['surface_based_cin'].attrs['long_name'] == 'Surface-based CIN'
+    np.testing.assert_almost_equal(sonde_ds['most_unstable_cape'], 0.000, decimal=3)
+    assert sonde_ds['most_unstable_cape'].attrs['units'] == 'J/kg'
+    assert sonde_ds['most_unstable_cape'].attrs['long_name'] == 'Most unstable CAPE'
+    np.testing.assert_almost_equal(sonde_ds['most_unstable_cin'], 0.000, decimal=3)
+    assert sonde_ds['most_unstable_cin'].attrs['units'] == 'J/kg'
+    assert sonde_ds['most_unstable_cin'].attrs['long_name'] == 'Most unstable CIN'
 
-    try:
-        sonde_ds = act.retrievals.calculate_stability_indicies(
-            sonde_ds, temp_name='tdry', td_name='dp', p_name='pres', rh_name='rh'
-        )
-        metpy = True
-    except ImportError:
-        metpy = False
-
-    if metpy is True:
-        np.testing.assert_allclose(
-            sonde_ds['parcel_temperature'].values[0:5],
-            [269.85, 269.745276, 269.678006, 269.622444, 269.572331],
-            rtol=1e-5,
-        )
-        assert sonde_ds['parcel_temperature'].attrs['units'] == 'kelvin'
-        np.testing.assert_almost_equal(sonde_ds['surface_based_cape'], 0.62, decimal=2)
-        assert sonde_ds['surface_based_cape'].attrs['units'] == 'J/kg'
-        assert sonde_ds['surface_based_cape'].attrs['long_name'] == 'Surface-based CAPE'
-        np.testing.assert_almost_equal(sonde_ds['surface_based_cin'], 0.000, decimal=3)
-        assert sonde_ds['surface_based_cin'].attrs['units'] == 'J/kg'
-        assert sonde_ds['surface_based_cin'].attrs['long_name'] == 'Surface-based CIN'
-        np.testing.assert_almost_equal(sonde_ds['most_unstable_cape'], 0.000, decimal=3)
-        assert sonde_ds['most_unstable_cape'].attrs['units'] == 'J/kg'
-        assert sonde_ds['most_unstable_cape'].attrs['long_name'] == 'Most unstable CAPE'
-        np.testing.assert_almost_equal(sonde_ds['most_unstable_cin'], 0.000, decimal=3)
-        assert sonde_ds['most_unstable_cin'].attrs['units'] == 'J/kg'
-        assert sonde_ds['most_unstable_cin'].attrs['long_name'] == 'Most unstable CIN'
-
-        np.testing.assert_almost_equal(sonde_ds['lifted_index'], 28.4, decimal=1)
-        assert sonde_ds['lifted_index'].attrs['units'] == 'kelvin'
-        assert sonde_ds['lifted_index'].attrs['long_name'] == 'Lifted index'
-        np.testing.assert_equal(sonde_ds['level_of_free_convection'], np.array(np.nan))
-        assert sonde_ds['level_of_free_convection'].attrs['units'] == 'hectopascal'
-        assert sonde_ds['level_of_free_convection'].attrs['long_name'] == 'Level of free convection'
-        np.testing.assert_almost_equal(
-            sonde_ds['lifted_condensation_level_temperature'], -8.07, decimal=2
-        )
-        assert sonde_ds['lifted_condensation_level_temperature'].attrs['units'] == 'degree_Celsius'
-        assert (
-            sonde_ds['lifted_condensation_level_temperature'].attrs['long_name']
-            == 'Lifted condensation level temperature'
-        )
-        np.testing.assert_almost_equal(
-            sonde_ds['lifted_condensation_level_pressure'], 927.1, decimal=1
-        )
-        assert sonde_ds['lifted_condensation_level_pressure'].attrs['units'] == 'hectopascal'
-        assert (
-            sonde_ds['lifted_condensation_level_pressure'].attrs['long_name']
-            == 'Lifted condensation level pressure'
-        )
+    np.testing.assert_almost_equal(sonde_ds['lifted_index'], 28.4, decimal=1)
+    assert sonde_ds['lifted_index'].attrs['units'] == 'kelvin'
+    assert sonde_ds['lifted_index'].attrs['long_name'] == 'Lifted index'
+    np.testing.assert_equal(sonde_ds['level_of_free_convection'], np.array(np.nan))
+    assert sonde_ds['level_of_free_convection'].attrs['units'] == 'hectopascal'
+    assert sonde_ds['level_of_free_convection'].attrs['long_name'] == 'Level of free convection'
+    np.testing.assert_almost_equal(
+        sonde_ds['lifted_condensation_level_temperature'], -8.07, decimal=2)
+    assert sonde_ds['lifted_condensation_level_temperature'].attrs['units'] == 'degree_Celsius'
+    assert (
+        sonde_ds['lifted_condensation_level_temperature'].attrs['long_name']
+        == 'Lifted condensation level temperature')
+    np.testing.assert_almost_equal(
+        sonde_ds['lifted_condensation_level_pressure'], 927.1, decimal=1)
+    assert sonde_ds['lifted_condensation_level_pressure'].attrs['units'] == 'hectopascal'
+    assert (
+        sonde_ds['lifted_condensation_level_pressure'].attrs['long_name']
+        == 'Lifted condensation level pressure')
     sonde_ds.close()
 
 


### PR DESCRIPTION
Tests failed with metpy not installed, which shouldn't be the case, fixing functions to follow pytest skipif