### PR TITLE
Update README.txt for Link to discussions

### DIFF
--- a/examples/README.txt
+++ b/examples/README.txt
@@ -4,5 +4,5 @@ ACT Example Gallery
 This gallery houses examples on different use cases for act including
 downloading data from web APIs, visualization various types of data,
 and more.  If there are specific use cases you would like to see examples
-of, please head on over to the `ACT discussion page <https://github.com/ARM-DOE/ACT/discussions>`_
+of, please head on over to the ACT discussion page https://github.com/ARM-DOE/ACT/discussions
 on GitHub.


### PR DESCRIPTION
Just fixing the URL link in README file. The following characters are being added to the hyperlink.