### PR TITLE
FIX: lxml was needed and scikit and metpy qc tests weren't optional.

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -51,10 +51,6 @@ jobs:
           use-mamba: true
           miniforge-variant: Mambaforge
 
-      - name: Install ICARTT
-        run:
-          python -m pip install icartt
-
       - name: Install ACT
         run: |
           python -m pip install -e . --no-deps --force-reinstall

--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,7 @@ Optional Dependencies
 * `Cartopy <https://scitools.org.uk/cartopy/docs/latest/>`_  Mapping and geoplots
 * `Py-ART <https://arm-doe.github.io/pyart/>`_ Reading radar files, plotting and corrections
 * `scikit-posthocs <https://scikit-posthocs.readthedocs.io/en/latest/>`_ Using interquartile range or generalized Extreme Studentized Deviate quality control tests
+* `icartt <https://mbees.med.uni-augsburg.de/docs/icartt/2.0.0/>`_ icartt is an ICARTT file format reader and writer for Python
 
 Installation
 ~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -75,13 +75,14 @@ Dependencies
 * `Proj <https://proj.org/>`_
 * `Six <https://pypi.org/project/six/>`_
 * `Requests <https://2.python-requests.org/en/master/>`_
+* `MetPy <https://unidata.github.io/MetPy/latest/index.html>`_
 
 Optional Dependencies
 ~~~~~~~~~~~~~~~~~~~~~
 
 * `MPL2NC <https://github.com/peterkuma/mpl2nc>`_ Reading binary MPL data.
 * `Cartopy <https://scitools.org.uk/cartopy/docs/latest/>`_  Mapping and geoplots
-* `MetPy <https://unidata.github.io/MetPy/latest/index.html>`_ >= V1.0 Skew-T plotting and some stabilities indices calculations
+* `Py-ART <https://arm-doe.github.io/pyart/>`_ Reading radar files, plotting and corrections
 * `scikit-posthocs <https://scikit-posthocs.readthedocs.io/en/latest/>`_ Using interquartile range or generalized Extreme Studentized Deviate quality control tests
 
 Installation

--- a/act/plotting/skewtdisplay.py
+++ b/act/plotting/skewtdisplay.py
@@ -7,35 +7,18 @@ import warnings
 
 # Import third party libraries
 import matplotlib.pyplot as plt
+import metpy
+import metpy.calc as mpcalc
+from metpy.plots import SkewT
+from metpy.units import units
 import numpy as np
 import scipy
-
-try:
-    import metpy
-    import metpy.calc as mpcalc
-    from pkg_resources import DistributionNotFound
-
-    METPY_AVAILABLE = True
-except ImportError:
-    METPY_AVAILABLE = False
-except (ModuleNotFoundError, DistributionNotFound):
-    warnings.warn(
-        'MetPy is installed but could not be imported. '
-        + 'Please check your MetPy installation. Some features '
-        + 'will be disabled.',
-        ImportWarning,
-    )
-    METPY_AVAILABLE = False
 
 from copy import deepcopy
 
 # Import Local Libs
 from ..utils import datetime_utils as dt_utils
 from .plot import Display
-
-if METPY_AVAILABLE:
-    from metpy.plots import SkewT
-    from metpy.units import units
 
 
 class SkewTDisplay(Display):
@@ -70,10 +53,6 @@ class SkewTDisplay(Display):
     def __init__(self, obj, subplot_shape=(1,), ds_name=None, **kwargs):
         # We want to use our routine to handle subplot adding, not the main
         # one
-        if not METPY_AVAILABLE:
-            raise ImportError(
-                'MetPy need to be installed on your system to ' + 'make Skew-T plots.'
-            )
         new_kwargs = kwargs.copy()
         super().__init__(obj, None, ds_name, subplot_kw=dict(projection='skewx'), **new_kwargs)
 

--- a/act/qc/qctests.py
+++ b/act/qc/qctests.py
@@ -9,6 +9,8 @@ qcfilter class definition to make it callable.
 import warnings
 
 import dask.array as da
+from metpy.units import units
+from metpy.calc import add_height_to_pressure
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -1567,15 +1569,6 @@ class QCTests:
 
 
         """
-
-        try:
-            from metpy.units import units
-            from metpy.calc import add_height_to_pressure
-        except ImportError:
-            raise ImportError(
-                'MetPy needs to be installed on your system to run qcfilter.add_atmospheric_pressure_test() test.'
-            )
-
         data_units = self._obj[var_name].attrs['units']
         working_units = 'kPa'
         test_limit = test_limit * units(working_units)

--- a/act/qc/qctests.py
+++ b/act/qc/qctests.py
@@ -1305,15 +1305,17 @@ class QCTests:
         prepend_text=None,
     ):
         """
-        Method to perform an interquartile range outliers test on 1D data. Data that lie within the
-        lower and upper limits are considered non-outliers. The lower limit is the number
-        that lies coef IQRs below the first quartile; the upper limit is the number that
-        lies coef IQRs above the third quartile. This method will flag data
+        Method to perform an interquartile range outliers test on 1D data.
+        Data that lie within the lower and upper limits are considered
+        non-outliers. The lower limit is the number that lies coef IQRs below
+        the first quartile; the upper limit is the number that lies coef IQRs
+        above the third quartile. This method will flag data
         failing the test in the corresponding quality control variable.
 
-        The library used to perform test does not accept NaN values. The NaN values will
-        be filtered out prior to testing and outlier values will be matched after. This
-        can cause the test to run slower on large data sets.
+        The library used to perform test does not accept NaN values. The NaN
+        values will be filtered out prior to testing and outlier values will
+        be matched after. This can cause the test to run slower on large data
+        sets.
 
         Parameters
         ----------
@@ -1340,8 +1342,8 @@ class QCTests:
         Returns
         -------
         test_info : tuple
-            A tuple containing test information including var_name, qc variable name,
-            test_number, test_meaning, test_assessment
+            A tuple containing test information including var_name, qc
+            variable name, test_number, test_meaning, test_assessment
 
         """
 
@@ -1349,7 +1351,8 @@ class QCTests:
             from scikit_posthocs import outliers_iqr
         except ImportError:
             raise ImportError(
-                'scikit_posthocs needs to be installed on your system to ' + 'run this test.'
+                'scikit_posthocs needs to be installed on your system to '
+                'run add_iqr_test.'
             )
 
         if test_meaning is None:
@@ -1395,14 +1398,17 @@ class QCTests:
         prepend_text=None,
     ):
         """
-        Method to perform generalized Extreme Studentized Deviate test to detect one or more
-        outliers in a univariate data set that follows an approximately normal distribution.
-        Default is to find 5 outliers but can overestimate number of outliers and will only flag
-        values determined to be outliers. If set to find one outlier is the Grubbs test.
+        Method to perform generalized Extreme Studentized Deviate test to
+        detect one or more outliers in a univariate data set that follows an
+        approximately normal distribution. Default is to find 5 outliers but
+        can overestimate number of outliers and will only flag values
+        determined to be outliers. If set to find one outlier is the Grubbs
+        test.
 
-        The library used to perform test does not accept NaN values. The NaN values will
-        be filtered out prior to testing and outlier values will be matched after. This
-        can cause the test to run slower on large data sets.
+        The library used to perform test does not accept NaN values. The NaN
+        values will be filtered out prior to testing and outlier values will
+        be matched after. This can cause the test to run slower on large data
+        sets.
 
         Parameters
         ----------
@@ -1410,9 +1416,10 @@ class QCTests:
             Data variable name.
         outliers : int or float
             Number of outliers to test for. If set to 1 is the Grubbs test.
-            If set to float values less than one will calcualte the number of outliers to test for.
-            Float value from 0 to 0.9 will be multiplied by the number of data values to
-            determine number of outliers to check. If set to value larger than 0.9 will use 0.9.
+            If set to float values less than one will calcualte the number of
+            outliers to test for. Float value from 0 to 0.9 will be multiplied
+            by the number of data values to determine number of outliers to
+            check. If set to value larger than 0.9 will use 0.9.
         alpha : float
             Significance level for a hypothesis test
         test_meaning : str
@@ -1434,8 +1441,8 @@ class QCTests:
         Returns
         -------
         test_info : tuple
-            A tuple containing test information including var_name, qc variable name,
-            test_number, test_meaning, test_assessment
+            A tuple containing test information including var_name, qc
+            variable name, test_number, test_meaning, test_assessment
 
         """
 
@@ -1443,7 +1450,8 @@ class QCTests:
             from scikit_posthocs import outliers_gesd
         except ImportError:
             raise ImportError(
-                'scikit_posthocs needs to be installed on your system to ' + 'run this test.'
+                'scikit_posthocs needs to be installed on your system to '
+                'run add_gesd_test.'
             )
 
         if test_meaning is None:
@@ -1503,9 +1511,10 @@ class QCTests:
         use_dask=False
     ):
         """
-        Method to perform a limit test on atmospheric pressure data using pressure derived from
-        altitude value. Will use the derived pressure as a mean and apply upper and lower
-        limit test on the data, flagging where outside the limit range.
+        Method to perform a limit test on atmospheric pressure data using
+        pressure derived from altitude value. Will use the derived pressure as
+        a mean and apply upper and lower limit test on the data, flagging
+        where outside the limit range.
 
         Parameters
         ----------
@@ -1514,15 +1523,17 @@ class QCTests:
         alt_name : str
             Altitude data variable name within the Dataset
         test_limit : int or float
-            Test range value to add/subtract from derived pressure value to set range limits.
+            Test range value to add/subtract from derived pressure value to
+            set range limits.
         sea_level_pressure : float
             Sea level pressure in kPa used for deriving pressure at altitude.
         bias : float
-            The derived pressure value in has a slight bias from typically measured values. This allows
-            adjusting the limts. This value in units of kPa is added to the derived pressure value.
+            The derived pressure value in has a slight bias from typically
+            measured values. This allows adjusting the limits. This value in
+            units of kPa is added to the derived pressure value.
         test_meaning : str
-            Optional text description to add to flag_meanings
-            describing the test. Will use a default if not set.
+            Optional text description to add to flag_meanings describing the
+            test. Will use a default if not set.
         test_assessment : str
             Optional single word describing the assessment of the test.
             Will use a default if not set.
@@ -1530,19 +1541,19 @@ class QCTests:
             Optional test number to use. If not set will use next available
             test number.
         flag_value : boolean
-            Indicates that the tests are stored as integers
-            not bit packed values in quality control variable.
+            Indicates that the tests are stored as integers not bit packed
+            values in quality control variable.
         prepend_text : str
-            Optional text to prepend to the test meaning.
-            Example is indicate what institution added the test.
+            Optional text to prepend to the test meaning. Example is indicate
+            what institution added the test.
         use_dask : boolean
-            Option to use Dask for searching if data is stored in a Dask array
+            Option to use Dask for searching if data is stored in a Dask array.
 
         Returns
         -------
         test_info : tuple
-            A tuple containing test information including var_name, qc variable name,
-            test_number, test_meaning, test_assessment
+            A tuple containing test information including var_name, qc
+            variable name, test_number, test_meaning, test_assessment.
 
         Examples
         --------

--- a/act/retrievals/sonde.py
+++ b/act/retrievals/sonde.py
@@ -5,30 +5,13 @@ Functions for radiosonde related calculations.
 
 import warnings
 
+import metpy.calc as mpcalc
+from metpy.units import units
 import numpy as np
 import pandas as pd
 import xarray as xr
 
 from act.utils.data_utils import convert_to_potential_temp
-
-try:
-    import metpy.calc as mpcalc
-    from pkg_resources import DistributionNotFound
-
-    METPY_AVAILABLE = True
-except ImportError:
-    METPY_AVAILABLE = False
-except (ModuleNotFoundError, DistributionNotFound):
-    warnings.warn(
-        'MetPy is installed but could not be imported. '
-        + 'Please check your MetPy installation. Some features '
-        + 'will be disabled.',
-        ImportWarning,
-    )
-    METPY_AVAILABLE = False
-
-if METPY_AVAILABLE:
-    from metpy.units import units
 
 
 def calculate_precipitable_water(ds, temp_name='tdry', rh_name='rh', pres_name='pres'):
@@ -144,11 +127,6 @@ def calculate_stability_indicies(
         An ACT dataset with additional stability indicies added.
 
     """
-    if not METPY_AVAILABLE:
-        raise ImportError(
-            'MetPy need to be installed on your system to ' + 'calculate stability indices'
-        )
-
     t = ds[temp_name]
     td = ds[td_name]
     p = ds[p_name]

--- a/act/tests/test_plotting.py
+++ b/act/tests/test_plotting.py
@@ -22,12 +22,6 @@ from act.plotting import (
 from act.utils.data_utils import accumulate_precip
 
 matplotlib.use('Agg')
-try:
-    import metpy.calc as mpcalc
-
-    METPY = True
-except ImportError:
-    METPY = False
 
 
 @pytest.mark.mpl_image_compare(tolerance=30)
@@ -307,7 +301,6 @@ def test_barb_sounding_plot():
         matplotlib.pyplot.close(BarbDisplay.fig)
 
 
-@pytest.mark.skipif(not METPY, reason="Metpy is not installed.")
 @pytest.mark.mpl_image_compare(tolerance=30)
 def test_skewt_plot():
     sonde_ds = arm.read_netcdf(sample_files.EXAMPLE_SONDE1)
@@ -320,7 +313,6 @@ def test_skewt_plot():
         matplotlib.pyplot.close(skewt.fig)
 
 
-@pytest.mark.skipif(not METPY, reason="Metpy is not installed.")
 @pytest.mark.mpl_image_compare(tolerance=30)
 def test_skewt_plot_spd_dir():
     sonde_ds = arm.read_netcdf(sample_files.EXAMPLE_SONDE1)
@@ -333,7 +325,6 @@ def test_skewt_plot_spd_dir():
         matplotlib.pyplot.close(skewt.fig)
 
 
-@pytest.mark.skipif(not METPY, reason="Metpy is not installed.")
 @pytest.mark.mpl_image_compare(tolerance=80)
 def test_multi_skewt_plot():
 

--- a/act/tests/test_qc.py
+++ b/act/tests/test_qc.py
@@ -25,6 +25,18 @@ from act.tests import (
 from act.qc.bsrn_tests import _calculate_solar_parameters
 from act.qc.add_supplemental_qc import read_yaml_supplemental_qc, apply_supplemental_qc
 
+try:
+    import metpy
+    METPY_AVAILABLE = True
+except ImportError:
+    METPY_AVAILABLE = False
+
+try:
+    import scikit_posthocs
+    SCIKIT_POSTHOCS_AVAILABLE = True
+except ImportError:
+    SCIKIT_POSTHOCS_AVAILABLE = False
+
 
 def test_fft_shading_test():
     obj = read_netcdf(EXAMPLE_MFRSR)
@@ -288,6 +300,8 @@ def test_qcfilter():
     ds_object.close()
 
 
+@pytest.mark.skipif(not SCIKIT_POSTHOCS_AVAILABLE,
+                    reason="scikit_posthocs is not installed.")
 def test_qcfilter2():
     ds_object = read_netcdf(EXAMPLE_IRT25m20s)
     var_name = 'inst_up_long_dome_resist'
@@ -1317,6 +1331,7 @@ def test_bsrn_limits_test():
         assert np.sum(result) == 100
 
 
+@pytest.mark.skipif(not METPY_AVAILABLE, reason="Metpy is not installed.")
 def test_add_atmospheric_pressure_test():
     ds_object = read_netcdf(EXAMPLE_MET1, cleanup_qc=True)
     ds_object.load()

--- a/act/tests/test_qc.py
+++ b/act/tests/test_qc.py
@@ -26,12 +26,6 @@ from act.qc.bsrn_tests import _calculate_solar_parameters
 from act.qc.add_supplemental_qc import read_yaml_supplemental_qc, apply_supplemental_qc
 
 try:
-    import metpy
-    METPY_AVAILABLE = True
-except ImportError:
-    METPY_AVAILABLE = False
-
-try:
     import scikit_posthocs
     SCIKIT_POSTHOCS_AVAILABLE = True
 except ImportError:
@@ -1331,7 +1325,6 @@ def test_bsrn_limits_test():
         assert np.sum(result) == 100
 
 
-@pytest.mark.skipif(not METPY_AVAILABLE, reason="Metpy is not installed.")
 def test_add_atmospheric_pressure_test():
     ds_object = read_netcdf(EXAMPLE_MET1, cleanup_qc=True)
     ds_object.load()

--- a/act/tests/test_retrievals.py
+++ b/act/tests/test_retrievals.py
@@ -1,6 +1,7 @@
 ' Unit tests for the ACT retrievals module. ' ''
 
 import glob
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -13,14 +14,7 @@ try:
 except ImportError:
     PYSP2_AVAILABLE = False
 
-try:
-    import metpy
-    METPY_AVAILABLE = True
-except ImportError:
-    METPY_AVAILABLE = False
 
-
-@pytest.mark.skipif(not METPY_AVAILABLE, reason="Metpy is not installed")
 def test_get_stability_indices():
     sonde_ds = act.io.armfiles.read_netcdf(act.tests.sample_files.EXAMPLE_SONDE1)
     sonde_ds = act.retrievals.calculate_stability_indicies(

--- a/act/utils/data_utils.py
+++ b/act/utils/data_utils.py
@@ -5,6 +5,8 @@ Module containing utilities for the data.
 
 import importlib
 import warnings
+
+import metpy
 import numpy as np
 import pint
 import scipy.stats as stats
@@ -15,22 +17,6 @@ if spec is not None:
     PYART_AVAILABLE = True
 else:
     PYART_AVAILABLE = False
-
-try:
-    import metpy
-    from pkg_resources import DistributionNotFound
-
-    METPY_AVAILABLE = True
-except ImportError:
-    METPY_AVAILABLE = False
-except (ModuleNotFoundError, DistributionNotFound):
-    warnings.warn(
-        'MetPy is installed but could not be imported. '
-        + 'Please check your MetPy installation. Some features '
-        + 'will be disabled.',
-        ImportWarning,
-    )
-    METPY_AVAILABLE = False
 
 
 @xr.register_dataset_accessor('utils')
@@ -787,12 +773,6 @@ def convert_to_potential_temp(
     doi:10.5065/D6WW7G29.
 
     """
-
-    if not METPY_AVAILABLE:
-        raise ImportError(
-            'MetPy needs to be installed on your system to ' 'convert to potential temperature'
-        )
-
     potential_temp = None
     if temp_var_units is None and temp_var_name is not None:
         temp_var_units = obj[temp_var_name].attrs['units']
@@ -886,12 +866,6 @@ def height_adjusted_temperature(
     doi:10.5065/D6WW7G29.
 
     """
-
-    if not METPY_AVAILABLE:
-        raise ImportError(
-            'MetPy needs to be installed on your system to ' 'convert temperature for height.'
-        )
-
     adjusted_temperature = None
     if temp_var_units is None and temperature is None:
         temp_var_units = obj[temp_var_name].attrs['units']
@@ -934,7 +908,6 @@ def height_adjusted_pressure(
     pressure=None,
     press_var_units=None,
 ):
-
     """
     Converts pressure for change in height.
 
@@ -972,13 +945,6 @@ def height_adjusted_pressure(
     doi:10.5065/D6WW7G29.
 
     """
-
-    if not METPY_AVAILABLE:
-        raise ImportError(
-            'MetPy needs to be installed on your system to '
-            'convert to convert pressure for change in height.'
-        )
-
     adjusted_pressure = None
     if press_var_units is None and pressure is None:
         press_var_units = obj[press_var_name].attrs['units']

--- a/continuous_integration/environment_actions.yml
+++ b/continuous_integration/environment_actions.yml
@@ -24,9 +24,10 @@ dependencies:
   - coveralls
   - shapely<1.8.3
   - pip
+  - lazy_loader
   - pip:
     - mpl2nc
     - metpy
     - pysp2
     - arm_pyart
-    - lazy_loader
+    - icartt

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -63,13 +63,15 @@ Dependencies
 | `Proj <https://proj.org/>`_
 | `Six <https://pypi.org/project/six/>`_
 | `Requests <https://2.python-requests.org/en/master/>`_
+| `MetPy <https://unidata.github.io/MetPy/latest/index.html>`_
 
 Optional Dependencies
 =====================
 
 | `MPL2NC <https://github.com/peterkuma/mpl2nc>`_ Reading binary MPL data.
-| `Cartopy <https://scitools.org.uk/cartopy/docs/latest/>`_  Mapping and geoplots
-| `MetPy <https://unidata.github.io/MetPy/latest/index.html>`_ >= V1.0 Skew-T plotting and some stabilities indices calculations
+| `Cartopy <https://scitools.org.uk/cartopy/docs/latest/>`_ Mapping and geoplots
+| `Py-ART <https://arm-doe.github.io/pyart/>`_ Reading radar files, plotting and corrections
+| `scikit-posthocs <https://scikit-posthocs.readthedocs.io/en/latest/>`_ Using interquartile range or generalized Extreme Studentized Deviate quality control tests
 
 
 Contributing

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -72,6 +72,7 @@ Optional Dependencies
 | `Cartopy <https://scitools.org.uk/cartopy/docs/latest/>`_ Mapping and geoplots
 | `Py-ART <https://arm-doe.github.io/pyart/>`_ Reading radar files, plotting and corrections
 | `scikit-posthocs <https://scikit-posthocs.readthedocs.io/en/latest/>`_ Using interquartile range or generalized Extreme Studentized Deviate quality control tests
+| `icartt <https://mbees.med.uni-augsburg.de/docs/icartt/2.0.0/>`_ icartt is an ICARTT file format reader and writer for Python
 
 
 Contributing

--- a/docs/source/userguide/installation.rst
+++ b/docs/source/userguide/installation.rst
@@ -2,17 +2,7 @@
 Installation
 ============
 
-In order to use ACT, you must have Python 3.6+ installed. We do not plan on
-having support for Python 2.x as it will be deprecated very soon.
-
-In addition, in order to make Skew-T plots, metpy is needed. In order to install
-MetPy, simply do::
-
-    $ pip install metpy
-
-Or, if you have Anaconda::
-
-    $ conda install -c conda-forge metpy
+In order to use ACT, you must have Python 3.6+ installed.
 
 You can build the Atmospheric data Community Toolkit from source and install it doing::
 
@@ -21,4 +11,10 @@ You can build the Atmospheric data Community Toolkit from source and install it 
     $ cd ACT
     $ python setup.py install
 
-We soon plan to implement pip install and conda install features.
+ACT is also available on Anaconda and PyPI. To install from PyPI:
+
+    $ pip install act-atmos
+
+To install from Anaconda conda-forge::
+
+    $ conda install -c conda-forge act-atmos

--- a/environment.yml
+++ b/environment.yml
@@ -18,3 +18,4 @@ dependencies:
   - cartopy
   - skyfield
   - lazy_loader
+  - lxml

--- a/examples/plot_skewt.py
+++ b/examples/plot_skewt.py
@@ -3,42 +3,34 @@ Skew-T plot of a sounding
 -------------------------
 
 This example shows how to make a Skew-T plot from a sounding
-and calculate stability indicies.  METPy needs to be installed
-in order to run this example
+and calculate stability indicies.
 
 """
 
 
-import xarray as xr
 from matplotlib import pyplot as plt
+import metpy
+import xarray as xr
 
 import act
 
 # Make sure attributes are retained
 xr.set_options(keep_attrs=True)
 
-try:
-    import metpy
+# Read data
+sonde_ds = act.io.armfiles.read_netcdf(act.tests.sample_files.EXAMPLE_SONDE1)
 
-    METPY = True
-except ImportError:
-    METPY = False
+print(list(sonde_ds))
+# Calculate stability indicies
+sonde_ds = act.retrievals.calculate_stability_indicies(
+    sonde_ds, temp_name='tdry', td_name='dp', p_name='pres', rh_name='rh'
+)
+print(sonde_ds['lifted_index'])
 
-if METPY:
-    # Read data
-    sonde_ds = act.io.armfiles.read_netcdf(act.tests.sample_files.EXAMPLE_SONDE1)
+# Set up plot
+skewt = act.plotting.SkewTDisplay(sonde_ds, figsize=(15, 10))
 
-    print(list(sonde_ds))
-    # Calculate stability indicies
-    sonde_ds = act.retrievals.calculate_stability_indicies(
-        sonde_ds, temp_name='tdry', td_name='dp', p_name='pres', rh_name='rh'
-    )
-    print(sonde_ds['lifted_index'])
-
-    # Set up plot
-    skewt = act.plotting.SkewTDisplay(sonde_ds, figsize=(15, 10))
-
-    # Add data
-    skewt.plot_from_u_and_v('u_wind', 'v_wind', 'pres', 'tdry', 'dp')
-    sonde_ds.close()
-    plt.show()
+# Add data
+skewt.plot_from_u_and_v('u_wind', 'v_wind', 'pres', 'tdry', 'dp')
+sonde_ds.close()
+plt.show()

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ lazy_loader
 fsspec
 lazy_loader
 icartt
+lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,4 @@ netcdf4
 lazy_loader
 fsspec
 lazy_loader
-icartt
 lxml


### PR DESCRIPTION
lxml is needed despite not existing in the ACT codebase itself but used by pandas. And fixing tests that weren't optional. 