### PR TITLE
MNT: Removes language warning.

### DIFF
--- a/docs/environment_docs.yml
+++ b/docs/environment_docs.yml
@@ -26,7 +26,6 @@ dependencies:
     - sphinx
     - sphinx_gallery
     - sphinx-copybutton
-    - sphinx
     - pydata-sphinx-theme<0.9.0
     - myst_nb
     - ablog

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -103,7 +103,7 @@ release = act.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
Was a duplicate sphinx install as well.