### PR TITLE
FIX: Fixes install issues for conda-forge. Namespace was being used incorrectly.

### DIFF
--- a/act/__init__.py
+++ b/act/__init__.py
@@ -9,10 +9,12 @@ import lazy_loader as lazy
 # No more pandas warnings
 from pandas.plotting import register_matplotlib_converters
 
-from . import tests
 from ._version import get_versions
 
 register_matplotlib_converters()
+
+# Import early so these classes are available to the object
+from .qc import QCFilter, QCTests, clean
 
 # Import the lazy loaded modules
 submodules = [
@@ -23,13 +25,9 @@ submodules = [
     'utils',
     'retrievals',
     'plotting',
+    'tests',
 ]
 __getattr__, __dir__, _ = lazy.attach(__name__, submodules)
-
-# Import early so these classes are available to the object
-from act.qc.qcfilter import QCFilter
-from act.qc.qctests import QCTests
-from act.qc import clean
 
 # Version for source builds
 vdict = get_versions()

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from os import path
-from setuptools import setup, find_namespace_packages
+from setuptools import setup, find_packages
 import sys
 import versioneer
 
@@ -46,7 +46,7 @@ setup(
     author='Adam Theisen',
     author_email='atheisen@anl.gov',
     url='https://github.com/ARM-DOE/ACT',
-    packages=find_namespace_packages(include=['act'], exclude=['docs']),
+    packages=find_packages(exclude=['docs']),
     entry_points={'console_scripts': []},
     include_package_data=True,
     package_data={'act': []},


### PR DESCRIPTION
My understanding of namespace packing was incorrect, so the submodule finding using namespace was conflicting with existing __init__.py files causing issues for installation. This should fix the feedstock testing. WIll need to look into more on why namespace warnings exist.