### PR TITLE
FIX: Add metpy to requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,5 @@ cftime
 netcdf4
 lazy_loader
 fsspec
-lazy_loader
+metpy
 lxml


### PR DESCRIPTION
adds metpy and removes duplicate lazy_loader closes #586 