### PR TITLE
ADD: New function for calculating PBL using the Heffter method

### DIFF
--- a/act/retrievals/sonde.py
+++ b/act/retrievals/sonde.py
@@ -521,7 +521,6 @@ def calculate_pbl_heffter(
         bottom_inversion.append(alt[r[0]])
         top_inversion.append(alt[r[1]])
         if pbl == 0 and theta_diff > 2.0:
-            # pbl = (alt[r[0]] + alt[r[1]]) / 2.
             pbl = alt[r[0]]
 
     if len(theta_diff_layer) == 0:
@@ -530,7 +529,6 @@ def calculate_pbl_heffter(
     # If PBL is not set, set it to the layer with the max theta diff
     if pbl == 0:
         idx = np.argmax(theta_diff_layer)
-        # pbl = (bottom_inversion[idx] + top_inversion[idx]) / 2.
         pbl = bottom_inversion[idx]
 
     # Add variables to the dataset

--- a/act/retrievals/sonde.py
+++ b/act/retrievals/sonde.py
@@ -291,7 +291,7 @@ def calculate_pbl_liu_liang(
 
     # Preprocess the sonde data to ensure the same methods across all retrievals
     ds2 = preprocess_sonde_data(ds, temperature=temperature, pressure=pressure,
-                                height=height, smooth_height=smooth_height, base=5)
+                                height=height, smooth_height=smooth_height, base=5.)
 
     pres = ds2[pressure].values
     wspd = ds2[windspeed].values
@@ -430,7 +430,7 @@ def calculate_pbl_heffter(
     pressure='pres',
     height='alt',
     smooth_height=3,
-    base=5,
+    base=5.,
 ):
     """
     Function for calculating the PBL height from a radiosonde profile
@@ -509,7 +509,7 @@ def calculate_pbl_heffter(
     # For each layer, calculate the difference in theta from
     # top and bottom of the layer.  The lowest layer where the
     # difference is > 2 K is set as the PBL.
-    pbl = 0
+    pbl = 0.
     theta_diff_layer = []
     bottom_inversion = []
     top_inversion = []
@@ -520,14 +520,14 @@ def calculate_pbl_heffter(
         theta_diff_layer.append(theta_diff)
         bottom_inversion.append(alt[r[0]])
         top_inversion.append(alt[r[1]])
-        if pbl == 0 and theta_diff > 2.0:
+        if pbl == 0. and theta_diff > 2.0:
             pbl = alt[r[0]]
 
     if len(theta_diff_layer) == 0:
         pbl = -9999.
 
     # If PBL is not set, set it to the layer with the max theta diff
-    if pbl == 0:
+    if pbl == 0.:
         idx = np.argmax(theta_diff_layer)
         pbl = bottom_inversion[idx]
 
@@ -565,7 +565,7 @@ def preprocess_sonde_data(
     pressure='pres',
     height='alt',
     smooth_height=3,
-    base=5,
+    base=5.,
 ):
     """
     Function for processing the SONDE data for the PBL calculations.
@@ -641,7 +641,7 @@ def preprocess_sonde_data(
     temp = ds2[temperature].values
 
     # Perform Pre-processing checks
-    if len(temp) == 0:
+    if len(temp) == 0.:
         raise ValueError('No data in profile')
 
     if np.nanmax(alt) < 1000.0:

--- a/act/retrievals/sonde.py
+++ b/act/retrievals/sonde.py
@@ -291,10 +291,9 @@ def calculate_pbl_liu_liang(
 
     # Preprocess the sonde data to ensure the same methods across all retrievals
     ds2 = preprocess_sonde_data(ds, temperature=temperature, pressure=pressure,
-                               height=height, smooth_height=smooth_height, base=5)
+                                height=height, smooth_height=smooth_height, base=5)
 
     pres = ds2[pressure].values
-    temp = ds2[temperature].values
     wspd = ds2[windspeed].values
     alt = ds2[height].values
 
@@ -475,7 +474,7 @@ def calculate_pbl_heffter(
 
     # Preprocess the sonde data to ensure the same methods across all retrievals
     ds2 = preprocess_sonde_data(ds, temperature=temperature, pressure=pressure,
-                               height=height, smooth_height=smooth_height, base=base)
+                                height=height, smooth_height=smooth_height, base=base)
 
     # Get data
     pres = ds2[pressure].values

--- a/act/retrievals/sonde.py
+++ b/act/retrievals/sonde.py
@@ -622,7 +622,7 @@ def preprocess_sonde_data(
     # it will smooth the data more.  This tends to happen if there are multiple
     # values of pressure that are the same
     try:
-        ds2 = ds2.sel(pres=p_grid, method='nearest')
+        ds2 = ds2.sel({pressure: p_grid}, method='nearest')
     except Exception:
         ds[pressure] = (
             ds[pressure].rolling(time=smooth_height + 4, min_periods=2, center=True).mean()
@@ -631,7 +631,7 @@ def preprocess_sonde_data(
         for var in ds2:
             ds2[var].attrs = ds[var].attrs
         try:
-            ds2 = ds2.sel(pres=p_grid, method='nearest')
+            ds2 = ds2.sel({pressure: p_grid}, method='nearest')
         except Exception:
             raise ValueError('Sonde profile does not have unique pressures after smoothing')
 

--- a/act/tests/test_retrievals.py
+++ b/act/tests/test_retrievals.py
@@ -235,7 +235,7 @@ def test_calculate_heffter_pbl():
     ds = act.retrievals.sonde.calculate_pbl_heffter(ds)
     assert ds['pblht_heffter'].values == 960.
     assert np.testing.assert_almost_equal(ds['atm_pres_ss'].values[1], 994.9, 1)
-    assert np.around(ds['potential_temperature_ss'].values[4], 1) == 298.4
+    assert np.testing.assert_almost_equal(ds['potential_temperature_ss'].values[4], 298.4, 1)
     assert np.sum(ds['bottom_inversion'].values) == 7426
     assert np.sum(ds['top_inversion'].values) == 7903
 

--- a/act/tests/test_retrievals.py
+++ b/act/tests/test_retrievals.py
@@ -229,7 +229,7 @@ def test_calculate_pbl_liu_liang():
 
 
 def test_calculate_heffter_pbl():
-    files = glob.glob(act.tests.sample_files.EXAMPLE_TWP_SONDE_20060121)
+    files = sorted(glob.glob(act.tests.sample_files.EXAMPLE_TWP_SONDE_20060121))
     ds = act.io.armfiles.read_netcdf(files[0])
     ds['tdry'].attrs['units'] = 'degree_Celsius'
     ds = act.retrievals.sonde.calculate_pbl_heffter(ds)

--- a/act/tests/test_retrievals.py
+++ b/act/tests/test_retrievals.py
@@ -235,7 +235,7 @@ def test_calculate_heffter_pbl():
     ds = act.retrievals.sonde.calculate_pbl_heffter(ds)
     assert ds['pblht_heffter'].values == 960.
     np.testing.assert_almost_equal(ds['atm_pres_ss'].values[1], 994.9, 1)
-    assert np.testing.assert_almost_equal(ds['potential_temperature_ss'].values[4], 298.4, 1)
+    np.testing.assert_almost_equal(ds['potential_temperature_ss'].values[4], 298.4, 1)
     assert np.sum(ds['bottom_inversion'].values) == 7426
     assert np.sum(ds['top_inversion'].values) == 7903
 

--- a/act/tests/test_retrievals.py
+++ b/act/tests/test_retrievals.py
@@ -185,12 +185,12 @@ def test_calculate_pbl_liu_liang():
         pbl_regime.append(obj['pblht_regime_liu_liang'].values)
 
     assert pbl_regime == ['NRL', 'NRL', 'NRL', 'NRL', 'NRL']
-    np.testing.assert_array_almost_equal(pblht, [847.5, 858.2, 184.8, 197.7, 443.2], decimal=1)
+    np.testing.assert_array_almost_equal(pblht, [1038.4, 1079., 282., 314., 643.], decimal=1)
 
     obj = act.io.armfiles.read_netcdf(files[1])
     obj['tdry'].attrs['units'] = 'degree_Celsius'
     obj = act.retrievals.sonde.calculate_pbl_liu_liang(obj, land_parameter=False)
-    np.testing.assert_almost_equal(obj['pblht_liu_liang'].values, 733.6, decimal=1)
+    np.testing.assert_almost_equal(obj['pblht_liu_liang'].values, 784, decimal=1)
 
     obj = act.io.armfiles.read_netcdf(files[-2:])
     obj['tdry'].attrs['units'] = 'degree_Celsius'
@@ -226,6 +226,18 @@ def test_calculate_pbl_liu_liang():
     obj['tdry'].values = temp
     with np.testing.assert_raises(ValueError):
         obj = act.retrievals.sonde.calculate_pbl_liu_liang(obj)
+
+
+def test_calculate_heffter_pbl():
+    files = glob.glob(act.tests.sample_files.EXAMPLE_TWP_SONDE_20060121)
+    ds = act.io.armfiles.read_netcdf(files[0])
+    ds['tdry'].attrs['units'] = 'degree_Celsius'
+    ds = act.retrievals.sonde.calculate_pbl_heffter(ds)
+    assert ds['pblht_heffter'].values == 960.
+    assert np.around(ds['atm_pres_ss'].values[1], 1) == 994.9
+    assert np.around(ds['potential_temperature_ss'].values[4], 1) == 298.4
+    assert np.sum(ds['bottom_inversion'].values) == 7426
+    assert np.sum(ds['top_inversion'].values) == 7903
 
 
 @pytest.mark.skipif(not PYSP2_AVAILABLE, reason="PySP2 is not installed.")

--- a/act/tests/test_retrievals.py
+++ b/act/tests/test_retrievals.py
@@ -230,7 +230,7 @@ def test_calculate_pbl_liu_liang():
 
 def test_calculate_heffter_pbl():
     files = sorted(glob.glob(act.tests.sample_files.EXAMPLE_TWP_SONDE_20060121))
-    ds = act.io.armfiles.read_netcdf(files[0])
+    ds = act.io.armfiles.read_netcdf(files[2])
     ds['tdry'].attrs['units'] = 'degree_Celsius'
     ds = act.retrievals.sonde.calculate_pbl_heffter(ds)
     assert ds['pblht_heffter'].values == 960.

--- a/act/tests/test_retrievals.py
+++ b/act/tests/test_retrievals.py
@@ -234,7 +234,7 @@ def test_calculate_heffter_pbl():
     ds['tdry'].attrs['units'] = 'degree_Celsius'
     ds = act.retrievals.sonde.calculate_pbl_heffter(ds)
     assert ds['pblht_heffter'].values == 960.
-    assert np.around(ds['atm_pres_ss'].values[1], 1) == 994.9
+    assert np.testing.assert_almost_equal(ds['atm_pres_ss'].values[1], 994.9, 1)
     assert np.around(ds['potential_temperature_ss'].values[4], 1) == 298.4
     assert np.sum(ds['bottom_inversion'].values) == 7426
     assert np.sum(ds['top_inversion'].values) == 7903

--- a/act/tests/test_retrievals.py
+++ b/act/tests/test_retrievals.py
@@ -234,7 +234,7 @@ def test_calculate_heffter_pbl():
     ds['tdry'].attrs['units'] = 'degree_Celsius'
     ds = act.retrievals.sonde.calculate_pbl_heffter(ds)
     assert ds['pblht_heffter'].values == 960.
-    assert np.testing.assert_almost_equal(ds['atm_pres_ss'].values[1], 994.9, 1)
+    np.testing.assert_almost_equal(ds['atm_pres_ss'].values[1], 994.9, 1)
     assert np.testing.assert_almost_equal(ds['potential_temperature_ss'].values[4], 298.4, 1)
     assert np.sum(ds['bottom_inversion'].values) == 7426
     assert np.sum(ds['top_inversion'].values) == 7903


### PR DESCRIPTION
This includes a second method (Heffter) for calculating PBL from radiosonde data.  I've compared with months of ARM VAP data and there are some slight differences due to different methods for gridding.  There are also some larger differences which upon investigation look like potential problems with the VAP.  These have been reported and are being looked at.  Currently there is a mean difference of -27m.

This method follows Heffter's criteria for finding PBL height with the same smoothing/gridding as was being performed in the Liu Liang method.  To this end, the overlapping preprocessing of the radiosonde data has been separated out into an individual function to simplify the codes.  This did cause some differences in the Liu Liang method, specifically the removal of the altitude smoothing.  The unit tests have been updated and the comparison with the VAP rerun yielding an average difference of 34m with a median of 5m.

![image](https://user-images.githubusercontent.com/13421074/220146678-8585084a-e64f-4ea1-906f-8e51d9dd7d5f.png)
