### PR TITLE
Updated to new required keyword in stats.mode(). 

### DIFF
--- a/act/tests/test_utils.py
+++ b/act/tests/test_utils.py
@@ -173,16 +173,16 @@ def test_accum_precip():
 
     ds = act.utils.accumulate_precip(ds, 'tbrg_precip_total')
     dmax = round(np.nanmax(ds['tbrg_precip_total_accumulated']))
-    assert dmax == 13.0
+    assert np.isclose(dmax, 13.0, atol=0.01)
 
     ds = act.utils.accumulate_precip(ds, 'tbrg_precip_total', time_delta=60)
     dmax = round(np.nanmax(ds['tbrg_precip_total_accumulated']))
-    assert dmax == 13.0
+    assert np.isclose(dmax, 13.0, atol=0.01)
 
     ds['tbrg_precip_total'].attrs['units'] = 'mm/hr'
     ds = act.utils.accumulate_precip(ds, 'tbrg_precip_total')
     dmax = np.round(np.nanmax(ds['tbrg_precip_total_accumulated']), 2)
-    assert dmax == 0.22
+    assert np.isclose(dmax, 0.22, atol=0.01)
 
 
 def test_calc_cog_sog():

--- a/act/utils/data_utils.py
+++ b/act/utils/data_utils.py
@@ -198,7 +198,7 @@ def add_in_nan(time, data):
         diff = np.diff(time, 1)
         # Wrapping in a try to catch error while switching between numpy 1.10 to 1.11
         try:
-            mode = stats.mode(diff, keepdims=False).mode[0]
+            mode = stats.mode(diff, keepdims=True).mode[0]
         except TypeError:
             mode = stats.mode(diff).mode[0]
         index = np.where(diff > (2.0 * mode))

--- a/act/utils/data_utils.py
+++ b/act/utils/data_utils.py
@@ -196,7 +196,11 @@ def add_in_nan(time, data):
         # Leaving code in here in case we need to update.
         # diff = np.diff(time.astype('datetime64[s]'), 1)
         diff = np.diff(time, 1)
-        mode = stats.mode(diff).mode[0]
+        # Wrapping in a try to catch error while switching between numpy 1.10 to 1.11
+        try:
+            mode = stats.mode(diff, keepdims=False).mode[0]
+        except TypeError:
+            mode = stats.mode(diff).mode[0]
         index = np.where(diff > (2.0 * mode))
 
         offset = 0
@@ -501,7 +505,10 @@ def accumulate_precip(ds, variable, time_delta=None):
     # Calculate mode of the time samples(i.e. 1 min vs 1 sec)
     if time_delta is None:
         diff = np.diff(time.values, 1) / np.timedelta64(1, 's')
-        t_delta = stats.mode(diff).mode
+        try:
+            t_delta = stats.mode(diff, keepdims=False).mode
+        except TypeError:
+            t_delta = stats.mode(diff).mode
     else:
         t_delta = time_delta
 

--- a/act/utils/datetime_utils.py
+++ b/act/utils/datetime_utils.py
@@ -133,7 +133,10 @@ def determine_time_delta(time, default=60):
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', category=RuntimeWarning)
         if time.size > 1:
-            mode = stats.mode(np.diff(time))
+            try:
+                mode = stats.mode(np.diff(time), keepdims=False)
+            except TypeError:
+                mode = stats.mode(np.diff(time))
             time_delta = mode.mode[0]
             time_delta = time_delta.astype('timedelta64[s]').astype(float)
         else:

--- a/act/utils/datetime_utils.py
+++ b/act/utils/datetime_utils.py
@@ -134,7 +134,7 @@ def determine_time_delta(time, default=60):
         warnings.filterwarnings('ignore', category=RuntimeWarning)
         if time.size > 1:
             try:
-                mode = stats.mode(np.diff(time), keepdims=False)
+                mode = stats.mode(np.diff(time), keepdims=True)
             except TypeError:
                 mode = stats.mode(np.diff(time))
             time_delta = mode.mode[0]


### PR DESCRIPTION
There is a warning from stats.mode() indicating that the need to indicate if a single value dimension should be dropped from the returned values. This PR explicitly sets the keyword to remove the warning and return a scalar when we desire a scalar.

Needed to add a try/except for the numpy 1.10 to 1.11 transition period. The keyword only exists in Numpy 1.11 and newer so for backward compatibility need to catch the error and use previous syntax.

- [X ] PEP8 Standards or use of linter
- [ X] Xarray Dataset or DataArray variable naming follows 'ds' or 'da' naming
