### PR TITLE
MNT: Missing kwargs from axes.step.

### DIFF
--- a/act/plotting/histogramdisplay.py
+++ b/act/plotting/histogramdisplay.py
@@ -448,8 +448,13 @@ class HistogramDisplay(Display):
                 )
             self.axes[subplot_index].legend()
         else:
+            if bins is None:
+                bmin = np.nanmin(xdata)
+                bmax = np.nanmax(xdata)
+                bins = np.arange(bmin, bmax, (bmax - bmin) / 10.0)
             my_hist, bins = np.histogram(xdata.values.flatten(), bins=bins,
                                          density=density, **hist_kwargs)
+
             x_inds = (bins[:-1] + bins[1:]) / 2.0
             self.axes[subplot_index].step(x_inds, my_hist, **kwargs)
 

--- a/act/plotting/histogramdisplay.py
+++ b/act/plotting/histogramdisplay.py
@@ -98,9 +98,8 @@ class HistogramDisplay(Display):
         subplot_index=(0,),
         set_title=None,
         density=False,
-        **hist_kwargs,
-        **kwargs
-    ):
+        hist_kwargs=dict(),
+        **kwargs):
         """
         This procedure will plot a stacked bar graph of a histogram.
 
@@ -126,7 +125,8 @@ class HistogramDisplay(Display):
             The title of the plot.
         density : bool
             Set to True to plot a p.d.f. instead of a frequency histogram.
-        **hist_kwargs : Additional keyword arguments to pass to numpy histogram.
+        hist_kwargs : dict
+            Additional keyword arguments to pass to numpy histogram.
 
         Other keyword arguments will be passed into :func:`matplotlib.pyplot.bar`.
 
@@ -177,14 +177,14 @@ class HistogramDisplay(Display):
             if bins is None:
                 my_hist, x_bins, y_bins = np.histogram2d(
                     xdata.values.flatten(), ydata.values.flatten(), density=density,
-                    **hist_kwargs)
+                    hist_kwargs)
             else:
                 my_hist, x_bins, y_bins = np.histogram2d(
                     xdata.values.flatten(),
                     ydata.values.flatten(),
                     density=density,
                     bins=[bins, sortby_bins],
-                    **hist_kwargs)
+                    hist_kwargs)
             x_inds = (x_bins[:-1] + x_bins[1:]) / 2.0
             self.axes[subplot_index].bar(
                 x_inds,
@@ -207,7 +207,7 @@ class HistogramDisplay(Display):
                 bmax = np.nanmax(xdata)
                 bins = np.arange(bmin, bmax, (bmax - bmin) / 10.0)
             my_hist, bins = np.histogram(xdata.values.flatten(), bins=bins,
-                                         density=density, **hist_kwargs)
+                                         density=density, hist_kwargs)
             x_inds = (bins[:-1] + bins[1:]) / 2.0
             self.axes[subplot_index].bar(x_inds, my_hist)
 
@@ -343,7 +343,7 @@ class HistogramDisplay(Display):
         subplot_index=(0,),
         set_title=None,
         density=False,
-        **hist_kwargs,
+        hist_kwargs,
         **kwargs,
     ):
         """
@@ -371,7 +371,8 @@ class HistogramDisplay(Display):
             The title of the plot.
         density : bool
             Set to True to plot a p.d.f. instead of a frequency histogram.
-        **hist_kwargs : Additional keyword arguments to pass to numpy histogram.
+        hist_kwargs : dict
+            Additional keyword arguments to pass to numpy histogram.
 
         Other keyword arguments will be passed into :func:`matplotlib.pyplot.step`.
 
@@ -421,14 +422,14 @@ class HistogramDisplay(Display):
             if bins is None:
                 my_hist, x_bins, y_bins = np.histogram2d(
                     xdata.values.flatten(), ydata.values.flatten(),
-                    density=density, **hist_kwargs)
+                    density=density, hist_kwargs)
             else:
                 my_hist, x_bins, y_bins = np.histogram2d(
                     xdata.values.flatten(),
                     ydata.values.flatten(),
                     density=density,
                     bins=[bins, sortby_bins],
-                    **hist_kwargs
+                    hist_kwargs
                 )
             x_inds = (x_bins[:-1] + x_bins[1:]) / 2.0
             self.axes[subplot_index].step(
@@ -447,7 +448,7 @@ class HistogramDisplay(Display):
             self.axes[subplot_index].legend()
         else:
             my_hist, bins = np.histogram(xdata.values.flatten(), bins=bins,
-                                         density=density, **hist_kwargs)
+                                         density=density, hist_kwargs)
             x_inds = (bins[:-1] + bins[1:]) / 2.0
             self.axes[subplot_index].step(x_inds, my_hist, **kwargs)
 
@@ -516,7 +517,7 @@ class HistogramDisplay(Display):
         set_shading : string
             Option to to set the matplotlib.pcolormesh shading parameter.
             Default to 'auto'
-        **hist_kwargs : Additional keyword arguments to pass to numpy histogram.
+        hist_kwargs : Additional keyword arguments to pass to numpy histogram.
 
         Other keyword arguments will be passed into :func:`matplotlib.pyplot.pcolormesh`.
 
@@ -564,14 +565,14 @@ class HistogramDisplay(Display):
         if x_bins is None:
             my_hist, x_bins, y_bins = np.histogram2d(
                 xdata.values.flatten(), ydata.values.flatten(), density=density,
-                **hist_kwargs)
+                hist_kwargs)
         else:
             my_hist, x_bins, y_bins = np.histogram2d(
                 xdata.values.flatten(),
                 ydata.values.flatten(),
                 density=density,
                 bins=[x_bins, y_bins],
-                **hist_kwargs
+                hist_kwargs
             )
         x_inds = (x_bins[:-1] + x_bins[1:]) / 2.0
         y_inds = (y_bins[:-1] + y_bins[1:]) / 2.0

--- a/act/plotting/histogramdisplay.py
+++ b/act/plotting/histogramdisplay.py
@@ -177,14 +177,14 @@ class HistogramDisplay(Display):
             if bins is None:
                 my_hist, x_bins, y_bins = np.histogram2d(
                     xdata.values.flatten(), ydata.values.flatten(), density=density,
-                    hist_kwargs)
+                    **hist_kwargs)
             else:
                 my_hist, x_bins, y_bins = np.histogram2d(
                     xdata.values.flatten(),
                     ydata.values.flatten(),
                     density=density,
                     bins=[bins, sortby_bins],
-                    hist_kwargs)
+                    **hist_kwargs)
             x_inds = (x_bins[:-1] + x_bins[1:]) / 2.0
             self.axes[subplot_index].bar(
                 x_inds,
@@ -207,7 +207,7 @@ class HistogramDisplay(Display):
                 bmax = np.nanmax(xdata)
                 bins = np.arange(bmin, bmax, (bmax - bmin) / 10.0)
             my_hist, bins = np.histogram(xdata.values.flatten(), bins=bins,
-                                         density=density, hist_kwargs)
+                                         density=density, **hist_kwargs)
             x_inds = (bins[:-1] + bins[1:]) / 2.0
             self.axes[subplot_index].bar(x_inds, my_hist)
 
@@ -422,14 +422,14 @@ class HistogramDisplay(Display):
             if bins is None:
                 my_hist, x_bins, y_bins = np.histogram2d(
                     xdata.values.flatten(), ydata.values.flatten(),
-                    density=density, hist_kwargs)
+                    density=density, **hist_kwargs)
             else:
                 my_hist, x_bins, y_bins = np.histogram2d(
                     xdata.values.flatten(),
                     ydata.values.flatten(),
                     density=density,
                     bins=[bins, sortby_bins],
-                    hist_kwargs
+                    **hist_kwargs
                 )
             x_inds = (x_bins[:-1] + x_bins[1:]) / 2.0
             self.axes[subplot_index].step(
@@ -448,7 +448,7 @@ class HistogramDisplay(Display):
             self.axes[subplot_index].legend()
         else:
             my_hist, bins = np.histogram(xdata.values.flatten(), bins=bins,
-                                         density=density, hist_kwargs)
+                                         density=density, **hist_kwargs)
             x_inds = (bins[:-1] + bins[1:]) / 2.0
             self.axes[subplot_index].step(x_inds, my_hist, **kwargs)
 
@@ -566,14 +566,14 @@ class HistogramDisplay(Display):
         if x_bins is None:
             my_hist, x_bins, y_bins = np.histogram2d(
                 xdata.values.flatten(), ydata.values.flatten(), density=density,
-                hist_kwargs)
+                **hist_kwargs)
         else:
             my_hist, x_bins, y_bins = np.histogram2d(
                 xdata.values.flatten(),
                 ydata.values.flatten(),
                 density=density,
                 bins=[x_bins, y_bins],
-                hist_kwargs
+                **hist_kwargs
             )
         x_inds = (x_bins[:-1] + x_bins[1:]) / 2.0
         y_inds = (y_bins[:-1] + y_bins[1:]) / 2.0

--- a/act/plotting/histogramdisplay.py
+++ b/act/plotting/histogramdisplay.py
@@ -98,7 +98,8 @@ class HistogramDisplay(Display):
         subplot_index=(0,),
         set_title=None,
         density=False,
-        **kwargs,
+        **hist_kwargs,
+        **kwargs
     ):
         """
         This procedure will plot a stacked bar graph of a histogram.
@@ -123,8 +124,9 @@ class HistogramDisplay(Display):
             The subplot index to place the plot in
         set_title : str
             The title of the plot.
-        density: bool
+        density : bool
             Set to True to plot a p.d.f. instead of a frequency histogram.
+        **hist_kwargs : Additional keyword arguments to pass to numpy histogram.
 
         Other keyword arguments will be passed into :func:`matplotlib.pyplot.bar`.
 
@@ -174,15 +176,15 @@ class HistogramDisplay(Display):
                 ytitle = field
             if bins is None:
                 my_hist, x_bins, y_bins = np.histogram2d(
-                    xdata.values.flatten(), ydata.values.flatten(), density=density
-                )
+                    xdata.values.flatten(), ydata.values.flatten(), density=density,
+                    **hist_kwargs)
             else:
                 my_hist, x_bins, y_bins = np.histogram2d(
                     xdata.values.flatten(),
                     ydata.values.flatten(),
                     density=density,
                     bins=[bins, sortby_bins],
-                )
+                    **hist_kwargs)
             x_inds = (x_bins[:-1] + x_bins[1:]) / 2.0
             self.axes[subplot_index].bar(
                 x_inds,
@@ -204,7 +206,8 @@ class HistogramDisplay(Display):
                 bmin = np.nanmin(xdata)
                 bmax = np.nanmax(xdata)
                 bins = np.arange(bmin, bmax, (bmax - bmin) / 10.0)
-            my_hist, bins = np.histogram(xdata.values.flatten(), bins=bins, density=density)
+            my_hist, bins = np.histogram(xdata.values.flatten(), bins=bins,
+                                         density=density, **hist_kwargs)
             x_inds = (bins[:-1] + bins[1:]) / 2.0
             self.axes[subplot_index].bar(x_inds, my_hist)
 
@@ -340,6 +343,7 @@ class HistogramDisplay(Display):
         subplot_index=(0,),
         set_title=None,
         density=False,
+        **hist_kwargs,
         **kwargs,
     ):
         """
@@ -367,6 +371,7 @@ class HistogramDisplay(Display):
             The title of the plot.
         density : bool
             Set to True to plot a p.d.f. instead of a frequency histogram.
+        **hist_kwargs : Additional keyword arguments to pass to numpy histogram.
 
         Other keyword arguments will be passed into :func:`matplotlib.pyplot.step`.
 
@@ -415,14 +420,15 @@ class HistogramDisplay(Display):
                 ytitle = field
             if bins is None:
                 my_hist, x_bins, y_bins = np.histogram2d(
-                    xdata.values.flatten(), ydata.values.flatten(), density=density
-                )
+                    xdata.values.flatten(), ydata.values.flatten(),
+                    density=density, **hist_kwargs)
             else:
                 my_hist, x_bins, y_bins = np.histogram2d(
                     xdata.values.flatten(),
                     ydata.values.flatten(),
                     density=density,
                     bins=[bins, sortby_bins],
+                    **hist_kwargs
                 )
             x_inds = (x_bins[:-1] + x_bins[1:]) / 2.0
             self.axes[subplot_index].step(
@@ -440,7 +446,8 @@ class HistogramDisplay(Display):
                 )
             self.axes[subplot_index].legend()
         else:
-            my_hist, bins = np.histogram(xdata.values.flatten(), bins=bins, density=density)
+            my_hist, bins = np.histogram(xdata.values.flatten(), bins=bins,
+                                         density=density, **hist_kwargs)
             x_inds = (bins[:-1] + bins[1:]) / 2.0
             self.axes[subplot_index].step(x_inds, my_hist, **kwargs)
 
@@ -509,6 +516,7 @@ class HistogramDisplay(Display):
         set_shading : string
             Option to to set the matplotlib.pcolormesh shading parameter.
             Default to 'auto'
+        **hist_kwargs : Additional keyword arguments to pass to numpy histogram.
 
         Other keyword arguments will be passed into :func:`matplotlib.pyplot.pcolormesh`.
 
@@ -555,14 +563,15 @@ class HistogramDisplay(Display):
 
         if x_bins is None:
             my_hist, x_bins, y_bins = np.histogram2d(
-                xdata.values.flatten(), ydata.values.flatten(), density=density
-            )
+                xdata.values.flatten(), ydata.values.flatten(), density=density,
+                **hist_kwargs)
         else:
             my_hist, x_bins, y_bins = np.histogram2d(
                 xdata.values.flatten(),
                 ydata.values.flatten(),
                 density=density,
                 bins=[x_bins, y_bins],
+                **hist_kwargs
             )
         x_inds = (x_bins[:-1] + x_bins[1:]) / 2.0
         y_inds = (y_bins[:-1] + y_bins[1:]) / 2.0

--- a/act/plotting/histogramdisplay.py
+++ b/act/plotting/histogramdisplay.py
@@ -343,7 +343,7 @@ class HistogramDisplay(Display):
         subplot_index=(0,),
         set_title=None,
         density=False,
-        hist_kwargs,
+        hist_kwargs=dict(),
         **kwargs,
     ):
         """
@@ -488,6 +488,7 @@ class HistogramDisplay(Display):
         set_title=None,
         density=False,
         set_shading='auto',
+        hist_kwargs=dict(),
         **kwargs,
     ):
         """

--- a/act/plotting/histogramdisplay.py
+++ b/act/plotting/histogramdisplay.py
@@ -92,7 +92,7 @@ class HistogramDisplay(Display):
         self,
         field,
         dsname=None,
-        bins=None,
+        bins=10,
         sortby_field=None,
         sortby_bins=None,
         subplot_index=(0,),
@@ -111,9 +111,9 @@ class HistogramDisplay(Display):
         dsname : str or None
             The name of the datastream the field is contained in. Set
             to None to let ACT automatically determine this.
-        bins : array-like or None
-            The histogram bin boundaries to use. Set to None to use
-            numpy's default boundaries.
+        bins : array-like or int
+            The histogram bin boundaries to use. If not specified, numpy's
+            default 10 is used.
         sortby_field : str or None
             Set this option to a field name in order to sort the histograms
             by a given field parameter. For example, one can sort histograms of CO2
@@ -158,7 +158,7 @@ class HistogramDisplay(Display):
         else:
             xtitle = field
 
-        if bins is not None and sortby_bins is None and sortby_field is not None:
+        if sortby_bins is None and sortby_field is not None:
             # We will defaut the y direction to have the same # of bins as x
             sortby_bins = np.linspace(ydata.values.min(), ydata.values.max(), len(bins))
 
@@ -175,9 +175,10 @@ class HistogramDisplay(Display):
                 ytitle = ''.join(['(', ydata.attrs['units'], ')'])
             else:
                 ytitle = field
-            if bins is None:
+            if sortby_bins is None:
                 my_hist, x_bins, y_bins = np.histogram2d(
                     xdata.values.flatten(), ydata.values.flatten(), density=density,
+                    bins=bins,
                     **hist_kwargs)
             else:
                 my_hist, x_bins, y_bins = np.histogram2d(
@@ -203,10 +204,6 @@ class HistogramDisplay(Display):
                 )
             self.axes[subplot_index].legend()
         else:
-            if bins is None:
-                bmin = np.nanmin(xdata)
-                bmax = np.nanmax(xdata)
-                bins = np.arange(bmin, bmax, (bmax - bmin) / 10.0)
             my_hist, bins = np.histogram(xdata.values.flatten(), bins=bins,
                                          density=density, **hist_kwargs)
             x_inds = (bins[:-1] + bins[1:]) / 2.0
@@ -338,7 +335,7 @@ class HistogramDisplay(Display):
         self,
         field,
         dsname=None,
-        bins=None,
+        bins=10,
         sortby_field=None,
         sortby_bins=None,
         subplot_index=(0,),
@@ -357,9 +354,9 @@ class HistogramDisplay(Display):
         dsname : str or None
             The name of the datastream the field is contained in. Set
             to None to let ACT automatically determine this.
-        bins : array-like or None
-            The histogram bin boundaries to use. Set to None to use
-            numpy's default boundaries.
+        bins : array-like or int
+            The histogram bin boundaries to use. If not specified, numpy's
+            default 10 is used.
         sortby_field : str or None
             Set this option to a field name in order to sort the histograms
             by a given field parameter. For example, one can sort histograms of CO2
@@ -403,7 +400,7 @@ class HistogramDisplay(Display):
         if sortby_field is not None:
             ydata = self._ds[dsname][sortby_field]
 
-        if bins is not None and sortby_bins is None and sortby_field is not None:
+        if sortby_bins is None and sortby_field is not None:
             # We will defaut the y direction to have the same # of bins as x
             sortby_bins = np.linspace(ydata.values.min(), ydata.values.max(), len(bins))
 
@@ -420,9 +417,9 @@ class HistogramDisplay(Display):
                 ytitle = ''.join(['(', ydata.attrs['units'], ')'])
             else:
                 ytitle = field
-            if bins is None:
+            if sortby_bins is None:
                 my_hist, x_bins, y_bins = np.histogram2d(
-                    xdata.values.flatten(), ydata.values.flatten(),
+                    xdata.values.flatten(), ydata.values.flatten(), bins=bins,
                     density=density, **hist_kwargs)
             else:
                 my_hist, x_bins, y_bins = np.histogram2d(
@@ -448,10 +445,6 @@ class HistogramDisplay(Display):
                 )
             self.axes[subplot_index].legend()
         else:
-            if bins is None:
-                bmin = np.nanmin(xdata)
-                bmax = np.nanmax(xdata)
-                bins = np.arange(bmin, bmax, (bmax - bmin) / 10.0)
             my_hist, bins = np.histogram(xdata.values.flatten(), bins=bins,
                                          density=density, **hist_kwargs)
 

--- a/act/plotting/histogramdisplay.py
+++ b/act/plotting/histogramdisplay.py
@@ -99,7 +99,8 @@ class HistogramDisplay(Display):
         set_title=None,
         density=False,
         hist_kwargs=dict(),
-        **kwargs):
+        **kwargs,
+    ):
         """
         This procedure will plot a stacked bar graph of a histogram.
 

--- a/act/plotting/histogramdisplay.py
+++ b/act/plotting/histogramdisplay.py
@@ -324,7 +324,7 @@ class HistogramDisplay(Display):
             )
 
         self.axes[subplot_index].set_title(set_title)
-        self.axes[subplot_index].step(bins.values, xdata.values)
+        self.axes[subplot_index].step(bins.values, xdata.values, **kwargs)
         self.axes[subplot_index].set_xlabel(xtitle)
         self.axes[subplot_index].set_ylabel(ytitle)
 

--- a/act/tests/test_plotting.py
+++ b/act/tests/test_plotting.py
@@ -3,6 +3,7 @@ import glob
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+from numpy.testing import assert_allclose
 import pandas as pd
 import pytest
 import xarray as xr
@@ -1205,3 +1206,36 @@ def test_xlim_correction_plot():
     ds.close()
 
     return display.fig
+
+def test_histogram_kwargs():
+    files = sample_files.EXAMPLE_MET1
+    ds = arm.read_netcdf(files)
+    hist_kwargs = {'range': (-10, 10)}
+    histdisplay = HistogramDisplay(ds)
+    hist_dict = histdisplay.plot_stacked_bar_graph('temp_mean', bins=np.arange(-40, 40, 5),
+                                                   sortby_bins=np.arange(-40, 40, 5),
+                                                   hist_kwargs=hist_kwargs)
+    hist_array = np.array(
+        [0, 0, 0, 0, 0, 0, 493, 883, 64, 0, 0, 0, 0, 0, 0])
+    assert_allclose(hist_dict['histogram'], hist_array)
+    hist_dict = histdisplay.plot_stacked_bar_graph('temp_mean', hist_kwargs=hist_kwargs)
+    hist_array = np.array([0, 0, 950, 177, 249, 64, 0, 0, 0, 0])
+    assert_allclose(hist_dict['histogram'], hist_array)
+    
+    hist_dict_stair = histdisplay.plot_stairstep_graph('temp_mean', bins=np.arange(-40, 40, 5),
+                                                       sortby_bins=np.arange(-40, 40, 5),
+                                                       hist_kwargs=hist_kwargs)
+    hist_array = np.array(
+        [0, 0, 0, 0, 0, 0, 493, 883, 64, 0, 0, 0, 0, 0, 0])
+    assert_allclose(hist_dict_stair['histogram'], hist_array)
+    hist_dict_stair = histdisplay.plot_stairstep_graph('temp_mean', hist_kwargs=hist_kwargs)
+    hist_array = np.array([0, 0, 950, 177, 249, 64, 0, 0, 0, 0])
+    assert_allclose(hist_dict_stair['histogram'], hist_array)
+
+    hist_dict_heat = histdisplay.plot_heatmap('temp_mean', 'rh_mean', x_bins=np.arange(-60, 10, 1),
+                                              y_bins=np.linspace(0, 10000.0, 50),
+                                              hist_kwargs=hist_kwargs)
+    hist_array = [0.0, 0.0, 0.0, 0.0]
+    assert_allclose(hist_dict_heat['histogram'][0, 0:4], hist_array)
+    ds.close()
+    matplotlib.pyplot.close(fig=histdisplay.fig)

--- a/act/tests/test_plotting.py
+++ b/act/tests/test_plotting.py
@@ -1207,6 +1207,7 @@ def test_xlim_correction_plot():
 
     return display.fig
 
+
 def test_histogram_kwargs():
     files = sample_files.EXAMPLE_MET1
     ds = arm.read_netcdf(files)
@@ -1221,7 +1222,7 @@ def test_histogram_kwargs():
     hist_dict = histdisplay.plot_stacked_bar_graph('temp_mean', hist_kwargs=hist_kwargs)
     hist_array = np.array([0, 0, 950, 177, 249, 64, 0, 0, 0, 0])
     assert_allclose(hist_dict['histogram'], hist_array)
-    
+
     hist_dict_stair = histdisplay.plot_stairstep_graph('temp_mean', bins=np.arange(-40, 40, 5),
                                                        sortby_bins=np.arange(-40, 40, 5),
                                                        hist_kwargs=hist_kwargs)

--- a/examples/plotting/plot_hist_kwargs.py
+++ b/examples/plotting/plot_hist_kwargs.py
@@ -17,7 +17,7 @@ met_ds = act.io.armfiles.read_netcdf(files)
 
 # Plot data
 hist_kwargs = {'range': (-10, 10)}
-histdisplay = HistogramDisplay(ds)
+histdisplay = act.plotting.HistogramDisplay(met_ds)
 histdisplay.plot_stacked_bar_graph('temp_mean', bins=np.arange(-40, 40, 5),
                                    hist_kwargs=hist_kwargs)
 plt.show()

--- a/examples/plotting/plot_hist_kwargs.py
+++ b/examples/plotting/plot_hist_kwargs.py
@@ -1,0 +1,23 @@
+"""
+Plot a histogram of Met data.
+----------------------------------------------------
+
+This is a simple example for how to plot a histogram
+of Meteorological data, while using hist_kwargs parameter.
+
+Author: Zachary Sherman
+"""
+
+from matplotlib import pyplot as plt
+
+import act
+
+files = act.tests.sample_files.EXAMPLE_MET1
+met_ds = act.io.armfiles.read_netcdf(files)
+
+# Plot data
+hist_kwargs = {'range': (-10, 10)}
+histdisplay = HistogramDisplay(ds)
+histdisplay.plot_stacked_bar_graph('temp_mean', bins=np.arange(-40, 40, 5),
+                                   hist_kwargs=hist_kwargs)
+plt.show()

--- a/examples/plotting/plot_hist_kwargs.py
+++ b/examples/plotting/plot_hist_kwargs.py
@@ -9,6 +9,7 @@ Author: Zachary Sherman
 """
 
 from matplotlib import pyplot as plt
+import numpy as np
 
 import act
 


### PR DESCRIPTION
- [x] Closes #650 
- [x] PEP8 Standards or use of linter
- [x] Xarray Dataset or DataArray variable naming follows 'ds' or 'da' naming
