### PR TITLE
Fix Airnow Test

### DIFF
--- a/act/tests/test_discovery.py
+++ b/act/tests/test_discovery.py
@@ -155,7 +155,7 @@ def test_airnow():
         results = act.discovery.get_airnow_forecast(token, '2022-05-01', zipcode=60108, distance=50)
         assert results['CategoryName'].values[0] == 'Good'
         assert results['AQI'].values[2] == -1
-        assert results['ReportingArea'][3] == 'Chicago'
+        assert results['ReportingArea'].values[3] == 'Chicago'
 
         results = act.discovery.get_airnow_forecast(
             token, '2022-05-01', distance=50, latlon=[41.958, -88.12]


### PR DESCRIPTION
Fix failing CI due to airnow test suite

- [x] Tests added
- [x] Documentation reflects changes
- [x] PEP8 Standards or use of linter
- [x] Xarray Dataset or DataArray variable naming follows 'ds' or 'da' naming
