### PR TITLE
FIX: Warnings for matplotlib new syntax. Has been fixed with new call.

### DIFF
--- a/act/plotting/geodisplay.py
+++ b/act/plotting/geodisplay.py
@@ -3,6 +3,7 @@ Stores the class for GeographicPlotDisplay.
 
 """
 
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -204,7 +205,7 @@ class GeographicPlotDisplay(Display):
 
         colorbar_map = None
         if cmap is not None:
-            colorbar_map = plt.cm.get_cmap(cmap)
+            colorbar_map = matplotlib.colormaps.get_cmap(cmap)
         sc = ax.scatter(lon, lat, c=data, cmap=colorbar_map, **kwargs)
         cbar = plt.colorbar(sc)
         cbar.ax.set_ylabel(cbar_label)

--- a/act/plotting/timeseriesdisplay.py
+++ b/act/plotting/timeseriesdisplay.py
@@ -1318,7 +1318,7 @@ class TimeSeriesDisplay(Display):
             except KeyError:
                 cb_label = data_field
 
-        colorbar_map = plt.cm.get_cmap(cmap)
+        colorbar_map = mpl.colormaps.get_cmap(cmap)
         self.fig.subplots_adjust(left=0.1, right=0.86, bottom=0.16, top=0.91)
         ax1 = self.plot(alt_field, color='black', **kwargs)
         ax1.set_ylabel(alt_label)

--- a/act/plotting/windrosedisplay.py
+++ b/act/plotting/windrosedisplay.py
@@ -5,6 +5,7 @@ Stores the class for WindRoseDisplay.
 
 import warnings
 
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -190,7 +191,7 @@ class WindRoseDisplay(Display):
         else:
             units = ''
         the_label = '%3.1f' % spd_bins[0] + '-' + '%3.1f' % spd_bins[1] + ' ' + units
-        our_cmap = plt.cm.get_cmap(cmap)
+        our_cmap = matplotlib.colormaps.get_cmap(cmap)
         our_colors = our_cmap(np.linspace(0, 1, len(spd_bins)))
 
         bars = [


### PR DESCRIPTION
This is to avoid the code breaking in a future matplotlib update.

- [x] PEP8 Standards or use of linter

