### PR TITLE
MNT: Update .gitignore to be more robust with downloaded test files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,18 +83,21 @@ target/
 *.xml
 
 # Test files downloaded locally
-act/tests/bck_Radar_FMCW_Bright_Band/
-act/tests/bck_Radar_FMCW_Moment/
-act/tests/ctd_449RWP_Bright_Band/
-act/tests/ctd_449RWP_Sub-Hour_Temp/
-act/tests/ctd_449RWP_Sub-Hour_Wind/
-act/tests/ctd_449RWP_Wind/
-act/tests/ctd_915RWP_Sub-Hour_Temp/
-act/tests/ctd_915RWP_Sub-Hour_Wind/
-act/tests/ctd_915RWP_Temp/
-act/tests/ctd_915RWP_Wind/
-act/tests/ctd_GpsTrimble/
-act/tests/ctd_Pressure/
-act/tests/ctd_Radar_S-band_Bright_Band/
-act/tests/ctd_Radar_S-band_Moment/
-act/tests/data/ctd*
+**/bck_Radar_FMCW_Bright_Band/
+**/bck_Radar_FMCW_Moment/
+**/ctd_449RWP_Bright_Band/
+**/ctd_449RWP_Sub-Hour_Temp/
+**/ctd_449RWP_Sub-Hour_Wind/
+**/ctd_449RWP_Wind/
+**/ctd_915RWP_Sub-Hour_Temp/
+**/ctd_915RWP_Sub-Hour_Wind/
+**/ctd_915RWP_Temp/
+**/ctd_915RWP_Wind/
+**/ctd_GpsTrimble/
+**/ctd_Pressure/
+**/ctd_Radar_S-band_Bright_Band/
+**/ctd_Radar_S-band_Moment/
+**/kps_Radar_FMCW_Moment/
+**/BARR_DP1.00002.001/
+data/*ctd
+act/tests/data/*stats*

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -386,6 +386,12 @@ For more on pytest:
 
 - https://docs.pytest.org/en/latest/
 
+Note: When testing ACT, the unit tests will download files from different
+datastreams as part of the tests. These files will download to the directory
+from where the tests were ran. These files will need to be added to the
+.gitignore if they are in a location that isn't caught by the .gitignore.
+More on using git can be seen below.
+
 
 Adding Changes to GitHub
 ------------------------


### PR DESCRIPTION

- [x] PEP8 Standards or use of linter

