### PR TITLE
Make sure to set units on datetime

### DIFF
--- a/act/io/csvfiles.py
+++ b/act/io/csvfiles.py
@@ -75,7 +75,7 @@ def read_csv(filename, sep=',', engine='python', column_names=None, skipfooter=0
 
     # Set Coordinates if there's a variable date_time
     if 'date_time' in df:
-        df.date_time = df.date_time.astype('datetime64')
+        df.date_time = df.date_time.astype('datetime64[ns]')
         df.time = df.date_time
         df = df.set_index('time')
 


### PR DESCRIPTION
Ensure units are set properly for datetime in csv reader

- [x] Closes #674 
- [x] Tests added
- [x] Documentation reflects changes
- [x] PEP8 Standards or use of linter
- [x] Xarray Dataset or DataArray variable naming follows 'ds' or 'da' naming
