### PR TITLE
BUG: Fixing title of violin example plot

### DIFF
--- a/examples/plotting/plot_violin.py
+++ b/examples/plotting/plot_violin.py
@@ -1,7 +1,9 @@
 """
 Investigate Temperature Quantiles
-using DistributionDisplay  Violin Plots
----------------------------------------
+---------------------------------
+
+Investigate Temperature Quantiles
+using DistributionDisplay Violin Plots
 
 Written: Joe O'Brien
 

--- a/examples/plotting/plot_violin.py
+++ b/examples/plotting/plot_violin.py
@@ -1,10 +1,7 @@
 """
 Investigate Temperature Quantiles
-with Violin Plots
----------------------------------
-
-Investigate temperature quantiles using
-DistributionDisplay Violin plot
+using DistributionDisplay  Violin Plots
+---------------------------------------
 
 Written: Joe O'Brien
 


### PR DESCRIPTION
the Violin Plotting example is currently not generating on the website due to repeating title information



