### PR TITLE
ADD: 'extract_arm_file_info' to harvest info from lists of ARM

### DIFF
--- a/act/io/__init__.py
+++ b/act/io/__init__.py
@@ -17,6 +17,7 @@ __getattr__, __dir__, __all__ = lazy.attach(
             'read_netcdf',
             'check_if_tar_gz_file',
             'read_mmcr',
+            'extract_arm_file_info',
         ],
         'csvfiles': ['read_csv'],
         'icartt': ['read_icartt'],

--- a/act/io/armfiles.py
+++ b/act/io/armfiles.py
@@ -761,7 +761,7 @@ class WriteDataset:
         current_time = dt.datetime.now().replace(microsecond=0)
         if 'history' in list(write_ds.attrs.keys()):
             write_ds.attrs['history'] += ''.join(['\n', str(current_time), ' created by ACT ', str(act.__version__),
-                                                   ' act.io.write.write_netcdf'])
+                                                  ' act.io.write.write_netcdf'])
 
         write_ds.to_netcdf(encoding=encoding, **kwargs)
 
@@ -923,8 +923,7 @@ def extract_arm_file_info(flist, d_loc=-15):
              "facility": [],
              "level": [],
              "times": [],
-             "datastream": [],
-            }
+             "datastream": []}
 
     # loop over filenames
     for fp in flist:

--- a/act/io/armfiles.py
+++ b/act/io/armfiles.py
@@ -920,11 +920,11 @@ def extract_arm_file_info(flist, d_loc=-15):
     """
     # Init output dict
     finfo = {"site": [],
-                  "facility": [],
-                  "level": [],
-                  "times": [],
-                  "datastream": [],
-                 }
+             "facility": [],
+             "level": [],
+             "times": [],
+             "datastream": [],
+            }
 
     # loop over filenames
     for fp in flist:

--- a/act/tests/test_io.py
+++ b/act/tests/test_io.py
@@ -925,3 +925,20 @@ def test_read_surfrad():
     assert ds['temperature'].values[0] == 2.0
     assert 'standard_name' in ds['temperature'].attrs
     assert ds['temperature'].attrs['standard_name'] == 'air_temperature'
+
+
+def test_extract_arm_file_info():
+    filenames = ['/first/path/to/data/nsakazrcfrcormdC1.c0.20191030.000001.nc',
+                 '/second/path/to/data/nsainterpolatedsondeC1.c1.20050327.000030.nc',
+                 '/third/path/to/data/sgpsondewnpnC1.b1.20170522.113300.cdf']
+    finfo = act.io.armfiles.extract_arm_file_info(filenames)
+
+    assert finfo["site"][1] == 'nsa'
+    assert finfo["site"][2] == 'sgp'
+    assert finfo["times"][1] == np.datetime64('2005-03-27T00:00:30')
+    assert finfo["facility"][0] == 'C1'
+    assert finfo["facility"][1] == 'C1'
+    assert finfo["level"][2] == 'b1'
+    assert finfo["level"][0] == 'c0'
+    assert finfo["datastream"][0] == 'kazrcfrcormd'
+    assert finfo["datastream"][2] == 'sondewnpn'


### PR DESCRIPTION
filenames without loading the files, thereby saving header reading and processing times

<!-- Please remove check-list items that aren't relevant to your changes -->

- [ ] Documentation reflects changes
