### PR TITLE
Fix `qcfilter.add_test` index

### DIFF
--- a/act/qc/qcfilter.py
+++ b/act/qc/qcfilter.py
@@ -553,7 +553,7 @@ class QCFilter(qctests.QCTests, comparison_tests.QCTests, bsrn_tests.QCTests):
             if flag_value:
                 qc_variable[index] = test_number
             else:
-                if np.size(qc_variable) > 1:
+                if bool(np.shape(index)):
                     qc_variable[index] = set_bit(qc_variable[index], test_number)
                 elif index == 0:
                     qc_variable = set_bit(qc_variable, test_number)

--- a/act/tests/test_qc.py
+++ b/act/tests/test_qc.py
@@ -204,6 +204,8 @@ def test_qcfilter():
     # Test adding QC for length-1 variables
     ds['west'] = ('west', ['W'])
     ds['avg_wind_speed'] = ('west', [20])
+
+    # Should not fail the test
     ds.qcfilter.add_test(
         'avg_wind_speed',
         index=ds.avg_wind_speed.data > 100,
@@ -211,6 +213,8 @@ def test_qcfilter():
         test_assessment='Suspect',
     )
     assert ds.qc_avg_wind_speed.data == 0
+
+    # Should fail the test
     ds.qcfilter.add_test(
         'avg_wind_speed',
         index=ds.avg_wind_speed.data < 100,
@@ -218,10 +222,20 @@ def test_qcfilter():
         test_assessment='Suspect',
     )
     assert ds.qc_avg_wind_speed.data == 2
+
+    # Should fail the test
     ds.qcfilter.add_test(
         'avg_wind_speed',
         index=[0],
         test_meaning='testing idx flag: true',
+        test_assessment='Suspect',
+    )
+    assert ds.qc_avg_wind_speed.data == 6
+
+    # Should not fail the test
+    ds.qcfilter.add_test(
+        'avg_wind_speed',
+        test_meaning='testing idx flag: false',
         test_assessment='Suspect',
     )
     assert ds.qc_avg_wind_speed.data == 6

--- a/act/tests/test_qc.py
+++ b/act/tests/test_qc.py
@@ -201,6 +201,31 @@ def test_qcfilter():
         == 0
     )
 
+    # Test adding QC for length-1 variables
+    ds['west'] = ('west', ['W'])
+    ds['avg_wind_speed'] = ('west', [20])
+    ds.qcfilter.add_test(
+        'avg_wind_speed',
+        index=ds.avg_wind_speed.data > 100,
+        test_meaning='testing bool flag: false',
+        test_assessment='Suspect',
+    )
+    assert ds.qc_avg_wind_speed.data == 0
+    ds.qcfilter.add_test(
+        'avg_wind_speed',
+        index=ds.avg_wind_speed.data < 100,
+        test_meaning='testing bool flag: true',
+        test_assessment='Suspect',
+    )
+    assert ds.qc_avg_wind_speed.data == 2
+    ds.qcfilter.add_test(
+        'avg_wind_speed',
+        index=[0],
+        test_meaning='testing idx flag: true',
+        test_assessment='Suspect',
+    )
+    assert ds.qc_avg_wind_speed.data == 6
+
     # Unset a test
     ds.qcfilter.unset_test(var_name, index=0, test_number=result['test_number'])
     # Remove the test


### PR DESCRIPTION
This PR fixes an issue where calling `ds.qcfilter.add_test(...)` with `index=np.array([False])` or `index=np.array([True])` would set the bit to the opposite of what it should be.

- [X] Tests added
- [X] PEP8 Standards or use of linter
- [X] Xarray Dataset or DataArray variable naming follows 'ds' or 'da' naming
