### PR TITLE
Allow pandas v2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # List required packages in this file, one per line.
 pyproj
 numpy
-pandas<2.0
+pandas
 matplotlib
 scipy
 xarray


### PR DESCRIPTION
This PR removes the `pandas<2.0` restriction in `requirements.txt`. Tests passing locally, no other changes needed.
