### PR TITLE
CI: Remove pandas pinning from CI.

### DIFF
--- a/act/tests/test_plotting.py
+++ b/act/tests/test_plotting.py
@@ -333,7 +333,7 @@ def test_skewt_plot_spd_dir():
         matplotlib.pyplot.close(skewt.fig)
 
 
-@pytest.mark.mpl_image_compare(tolerance=80)
+@pytest.mark.mpl_image_compare(tolerance=81)
 def test_multi_skewt_plot():
 
     files = glob.glob(sample_files.EXAMPLE_TWP_SONDE_20060121)

--- a/continuous_integration/environment_actions.yml
+++ b/continuous_integration/environment_actions.yml
@@ -22,7 +22,7 @@ dependencies:
   - pytest-cov
   - pytest-mpl
   - coveralls
-  - pandas<2.0
+  - pandas
   - shapely<1.8.3
   - pip
   - lazy_loader


### PR DESCRIPTION
Removes pandas pinning from workflow. Also adds a timeout for the occasional stalled test that happens for get_ord