### PR TITLE
Changing default behavior for data filter for V2.0.0

### DIFF
--- a/act/qc/qcfilter.py
+++ b/act/qc/qcfilter.py
@@ -951,7 +951,7 @@ class QCFilter(qctests.QCTests, comparison_tests.QCTests, bsrn_tests.QCTests):
         rm_assessments=None,
         rm_tests=None,
         verbose=False,
-        del_qc_var=True,
+        del_qc_var=False,
     ):
         """
         Method to apply quality control variables to data variables by
@@ -981,7 +981,7 @@ class QCFilter(qctests.QCTests, comparison_tests.QCTests, bsrn_tests.QCTests):
             the data values can not be determined after they are set to NaN
             and xarray method processing would also process the quality control
             variables, the default is to remove the quality control data
-            variables.
+            variables.  Defaults to False.
 
         Examples
         --------

--- a/act/tests/test_qc.py
+++ b/act/tests/test_qc.py
@@ -789,7 +789,7 @@ def test_datafilter():
 
     ds.qcfilter.add_less_test(var_name, 99, test_assessment='Bad')
     ds_filtered = copy.deepcopy(ds)
-    ds_filtered.qcfilter.datafilter(rm_assessments='Bad', del_qc_var=False)
+    ds_filtered.qcfilter.datafilter(rm_assessments='Bad')
     ds_2 = ds_filtered.mean()
     assert np.isclose(ds_1[var_name].values, 98.86, atol=0.01)
     assert np.isclose(ds_2[var_name].values, 99.15, atol=0.01)
@@ -797,7 +797,7 @@ def test_datafilter():
     assert 'act.qc.datafilter' in ds_filtered[var_name].attrs['history']
 
     ds_filtered = copy.deepcopy(ds)
-    ds_filtered.qcfilter.datafilter(rm_assessments='Bad', variables=var_name)
+    ds_filtered.qcfilter.datafilter(rm_assessments='Bad', variables=var_name, del_qc_var=True)
     ds_2 = ds_filtered.mean()
     assert np.isclose(ds_2[var_name].values, 99.15, atol=0.01)
     expected_var_names = sorted(list(set(data_var_names + qc_var_names) - set(['qc_' + var_name])))


### PR DESCRIPTION
<!-- Please remove check-list items that aren't relevant to your changes -->

- [ ] Closes #732 
- [ ] Documentation reflects changes
- [ ] PEP8 Standards or use of linter
- [ ] Xarray Dataset or DataArray variable naming follows 'ds' or 'da' naming
