### PR TITLE
converting data to numpy array before checking data with numpy function

### DIFF
--- a/act/plotting/timeseriesdisplay.py
+++ b/act/plotting/timeseriesdisplay.py
@@ -683,6 +683,12 @@ class TimeSeriesDisplay(Display):
                 our_data = ydata
 
             finite = np.isfinite(our_data)
+            # If finite is returned as DataArray or Dask array extract values.
+            try:
+                finite = finite.values
+            except AttributeError:
+                pass
+
             if finite.any():
                 our_data = our_data[finite]
                 if invert_y_axis is False:


### PR DESCRIPTION
Resolving issue when checking if data is finite when the data object type is not a Numpy array. This will try to extract the numpy array from the DataArray. Wrapped in a try to catch when the data is already a numpy array or is something else.

<!-- Please remove check-list items that aren't relevant to your changes -->

- [ X] Documentation reflects changes
- [ X] PEP8 Standards or use of linter
