### PR TITLE
ENH: Grammatical error in V2 guide and pointing readme to documentati…

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -287,8 +287,8 @@ When adding discovery modules or functions please adhere to the following
 * Filenames should just include the name of the organization (arm) or portal (airnow) and no other filler words like get or download
 * Functions should follow [get/download]_[org/portal]_[data/other description].  If it is getting data but not downloading a file, it should start with get, like get_asos_data. If it downloads a file, it should start with download.  The other description can vary depending on what you are retrieving.  Please check out the existing functions for ideas.
 
-Discovery
-~~~~~~~~~
+IO
+~~
 Similarly, for the io modules, the names should not have filler and just be the organization or portal name.  The functions should clearly indicate what it is doing like read_arm_netcdf instead of read_netcdf if the function is specific to ARM files.
 
 Adding Secrets and Environment Variables

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Version 2.0
 
 ACT will soon have a version 2.0 release. This release will contain many function
 naming changes such as IO and Discovery module function naming changes. To
-prepare for this release, a `v2.0 <https://github.com/ARM-DOE/ACT/blob/main/guides/GUIDE_V2.rst>`_
+prepare for this release, a `v2.0 <https://arm-doe.github.io/ACT/userguide/GUIDE_V2.html>`_
 has been provided that explains the changes and how to work with the new syntax.
 
 To test out the release candidate 2.0.0-rc.0 of ACT, use::

--- a/guides/GUIDE_V2.rst
+++ b/guides/GUIDE_V2.rst
@@ -2,7 +2,7 @@
 ACT Version 2 Release Guide
 ===========================
 
-In preparation for version 2.0.0 of ACT, codes were standardized for consistency purposes as furhter defined in the `Contributor's Guide <https://arm-doe.github.io/ACT/userguide/CONTRIBUTING.html>`_.  These changes will break some users code as the API has changed.  This guide will detail the changes for each module.
+In preparation for version 2.0.0 of ACT, codes were standardized for consistency purposes as further defined in the `Contributor's Guide <https://arm-doe.github.io/ACT/userguide/CONTRIBUTING.html>`_.  These changes will break some users code as the API has changed.  This guide will detail the changes for each module.
 
 Discovery
 =========


### PR DESCRIPTION
…on page of v2 guide.

<!-- Please remove check-list items that aren't relevant to your changes -->


- [x] Documentation reflects changes
- [x] PEP8 Standards or use of linter
