### PR TITLE
Correctly inserting two nan values for 2D plots to ensure minimal streaking in plot.

### DIFF
--- a/act/tests/test_utils.py
+++ b/act/tests/test_utils.py
@@ -86,12 +86,13 @@ def test_add_in_nan():
     time = np.arange('2019-01-01T01:00', '2019-01-01T02:00', dtype='datetime64[m]')
     data = np.random.random((len(time), 25))
 
-    time = np.delete(time, range(3,8))
-    data = np.delete(data, range(3,8), axis=0)
+    time = np.delete(time, range(3, 8))
+    data = np.delete(data, range(3, 8), axis=0)
     time_filled, data_filled = act.utils.add_in_nan(time, data)
 
-    assert np.count_nonzero(np.isnan(data_filled[3,:])) == 25
+    assert np.count_nonzero(np.isnan(data_filled[3, :])) == 25
     assert len(time_filled) == len(time) + 2
+
 
 def test_get_missing_value():
     ds = act.io.arm.read_arm_netcdf(act.tests.sample_files.EXAMPLE_EBBR1)

--- a/act/tests/test_utils.py
+++ b/act/tests/test_utils.py
@@ -82,6 +82,16 @@ def test_add_in_nan():
     index = np.where(time_filled == np.datetime64('2019-01-01T01:40'))[0]
     assert index.size == 0
 
+    # Test for 2D data
+    time = np.arange('2019-01-01T01:00', '2019-01-01T02:00', dtype='datetime64[m]')
+    data = np.random.random((len(time), 25))
+
+    time = np.delete(time, range(3,8))
+    data = np.delete(data, range(3,8), axis=0)
+    time_filled, data_filled = act.utils.add_in_nan(time, data)
+
+    assert np.count_nonzero(np.isnan(data_filled[3,:])) == 25
+    assert len(time_filled) == len(time) + 2
 
 def test_get_missing_value():
     ds = act.io.arm.read_arm_netcdf(act.tests.sample_files.EXAMPLE_EBBR1)


### PR DESCRIPTION
There is an issue with plotting multiple data files with a large data gap and 2D data. Inserting on NaN value allows the plot to streak the image. This PR will insert 2 NaN values to stop the streaking.

- [ X] Closes #766 
- [ X] Documentation reflects changes
- [ X] PEP8 Standards or use of linter

