### PR TITLE
Catching divide by 0 error before it errors.

### DIFF
--- a/act/qc/radiometer_tests.py
+++ b/act/qc/radiometer_tests.py
@@ -262,7 +262,11 @@ def fft_shading_test_process(
             # Calculates to the left/right of each peak
             peak_l = max(fftv[range(sind, index[0])])
             peak_r = max(fftv[range(index[-1], eind)])
-            ratio.append(peak / np.mean([peak_l, peak_r]))
+            mean_value = np.mean([peak_l, peak_r])
+            if mean_value == 0.0:
+                ratio.append(np.nan)
+            else:
+                ratio.append(peak / mean_value)
 
     # Checks ratios against thresholds for each freq range
     shading = 0


### PR DESCRIPTION
There is a chance that the division could cause error when the mean is zero. This just catches that instance and handles correctly.

- [ X ] PEP8 Standards or use of linter
