### PR TITLE
Unit conversion warning

### DIFF
--- a/act/io/hysplit.py
+++ b/act/io/hysplit.py
@@ -78,7 +78,7 @@ def read_hysplit(filename, base_year=2000):
         for variable in data[1:]:
             var_list.append(variable)
     input_df = pd.read_csv(
-        filename, sep='\s+', index_col=False, names=var_list, skiprows=12)
+        filename, sep='\s+', index_col=False, names=var_list, skiprows=12)  # noqa W605
     input_df['year'] = base_year + input_df['year']
     input_df['time'] = pd.to_datetime(input_df[["year", "month", "day", "hour", "minute"]],
                                       format='%y%m%d%H%M')

--- a/act/utils/data_utils.py
+++ b/act/utils/data_utils.py
@@ -35,7 +35,8 @@ class ChangeUnits:
         self._ds = ds
 
     def change_units(
-        self, variables=None, desired_unit=None, skip_variables=None, skip_standard=True
+        self, variables=None, desired_unit=None, skip_variables=None, skip_standard=True,
+        verbose=False, raise_error=False
     ):
         """
         Parameters
@@ -51,6 +52,13 @@ class ChangeUnits:
             Flag indicating the QC variables that will not need changing are
             skipped. Makes the processing faster when processing all variables
             in dataset.
+        verbose : boolean
+            Option to print statement when an attempted conversion fails. Set to False
+            as default because many units strings are not udunits complient and when
+            trying to convert all varialbes of a type of units (eg temperature) the code
+            can print a lot of unecessary information.
+        raise_error : boolean
+            Raise an error if conversion is not successful.
 
         Returns
         -------
@@ -102,7 +110,11 @@ class ChangeUnits:
                 pint.errors.UndefinedUnitError,
                 np.core._exceptions.UFuncTypeError,
             ):
-                continue
+                if raise_error:
+                    raise ValueError(f"Unable to convert '{var_name}' to units of '{desired_unit}'.")
+                elif verbose:
+                    print(f"\n    Unable to convert '{var_name}' to units of '{desired_unit}'. "
+                          f"Skipping unit converstion for '{var_name}'.\n")
 
         return self._ds
 

--- a/examples/plotting/plot_scatter.py
+++ b/examples/plotting/plot_scatter.py
@@ -31,7 +31,7 @@ display.plot_scatter('true_airspeed',
                      'ground_speed',
                      m_field='ambient_temp',
                      marker='x',
-                     cbar_label='Ambient Temperature ($^\circ$C)'
+                     cbar_label='Ambient Temperature ($^\circ$C)'  # noqa W605
                      )
 
 # Set the range of the field on the x-axis

--- a/tests/utils/test_data_utils.py
+++ b/tests/utils/test_data_utils.py
@@ -95,11 +95,6 @@ def test_convert_units():
     data = act.utils.data_utils.convert_units(r_data, 'K', 'C')
     assert np.ceil(data[0]) == 12
 
-    # try:
-    #     ds.utils.change_units()
-    # except ValueError as error:
-    #     assert str(error) == "Need to provide 'desired_unit' keyword for .change_units() method"
-
     with np.testing.assert_raises(ValueError):
         ds.utils.change_units()
 


### PR DESCRIPTION
This adds keywords to the convert_units method to notify user when the conversion fail. Because of how the method can loop through all the variables in the Dataset we don't want to print or raise exceptions when a conversion fails. This adds options the user can implement. I tried to use warnings but they didn't work so it's a print statement.

- [ X] Closes #793
- [X ] Tests added
- [ X] Documentation reflects changes
- [ X] PEP8 Standards or use of linter
- [X ] Xarray Dataset or DataArray variable naming follows 'ds' or 'da' naming
