### PR TITLE
FIX: Fix for new xarray check for dtype.

### DIFF
--- a/act/io/arm.py
+++ b/act/io/arm.py
@@ -767,6 +767,9 @@ class WriteDataset:
                 ]
             )
 
+        if 'time_bounds' in encoding.keys():
+            encoding['time_bounds']['dtype'] = 'float64'
+
         if hasattr(write_ds, 'time_bounds') and not write_ds.time.encoding:
             write_ds.time.encoding.update(write_ds.time_bounds.encoding)
 


### PR DESCRIPTION
Trying to understand the encoding was a learning experience to say the least. The input encoding is 'float64' so I set it to that. 'datetime64[ns]' does not work.