### PR TITLE
Airnow bug

### DIFF
--- a/act/discovery/airnow.py
+++ b/act/discovery/airnow.py
@@ -38,7 +38,7 @@ def get_airnow_forecast(token, date, zipcode=None, latlon=None, distance=25):
     """
 
     # default beginning of the query url
-    query_url = 'https://airnowapi.org/aq/forecast/'
+    query_url = 'https://www.airnowapi.org/aq/forecast/'
 
     # checking is either a zipcode or latlon coordinate is defined
     # if neither is defined then error is raised
@@ -47,7 +47,7 @@ def get_airnow_forecast(token, date, zipcode=None, latlon=None, distance=25):
 
     if zipcode:
         url = query_url + (
-            'zipcode/?'
+            'zipCode/?'
             + 'format=text/csv'
             + '&zipCode='
             + str(zipcode)
@@ -75,6 +75,7 @@ def get_airnow_forecast(token, date, zipcode=None, latlon=None, distance=25):
             + str(token)
         )
 
+    print(url)
     df = pd.read_csv(url)
 
     # converting to xarray dataset object

--- a/act/plotting/timeseriesdisplay.py
+++ b/act/plotting/timeseriesdisplay.py
@@ -198,7 +198,7 @@ class TimeSeriesDisplay(Display):
         for ii in noon:
             ax.axvline(x=ii, linestyle='--', color='y', zorder=1)
 
-    def set_xrng(self, xrng, subplot_index=(0, 0)):
+    def set_xrng(self, xrng, subplot_index=(0,)):
         """
         Sets the x range of the plot.
 
@@ -230,6 +230,7 @@ class TimeSeriesDisplay(Display):
                 )
                 xrng[0] -= dt.timedelta(seconds=1)
                 xrng[1] += dt.timedelta(seconds=1)
+
         self.axes[subplot_index].set_xlim(xrng)
 
         # Make sure that the xrng value is a numpy array not pandas


### PR DESCRIPTION
<!-- Please remove check-list items that aren't relevant to your changes -->


- [ ] PEP8 Standards or use of linter
- [ ] Xarray Dataset or DataArray variable naming follows 'ds' or 'da' naming
