### PR TITLE
Update DatastreamParser to accecpt pathlib.PosixPath

### DIFF
--- a/act/qc/comparison_tests.py
+++ b/act/qc/comparison_tests.py
@@ -85,9 +85,9 @@ class QCTests:
         sum_diff = np.array([], dtype=float)
         time_diff = np.array([], dtype=np.int32)
         for tm_shift in range(-1 * time_shift, time_shift + int(time_step), int(time_step)):
-            self_da_shifted = self_da.assign_coords(
-                time=self_da.time.values.astype('datetime64[s]') + tm_shift
-            )
+            time = self_da.time.values.astype('datetime64[s]') + tm_shift
+            time = time.astype('datetime64[ns]')
+            self_da_shifted = self_da.assign_coords(time=time)
 
             data_matched, comp_data_matched = xr.align(self_da, comp_da)
             self_da_shifted = self_da_shifted.reindex(

--- a/act/utils/data_utils.py
+++ b/act/utils/data_utils.py
@@ -15,6 +15,7 @@ import xarray as xr
 from pathlib import Path
 import re
 import requests
+from os import PathLike
 
 spec = importlib.util.find_spec('pyart')
 if spec is not None:
@@ -176,11 +177,10 @@ class DatastreamParserARM:
             The datastream or filename to parse
 
         '''
-
-        if isinstance(ds, str):
+        if isinstance(ds, (str, PathLike)):
             self.__datastream = Path(ds).name
         else:
-            raise ValueError('Datastream or filename name must be a string')
+            raise ValueError('Datastream or filename name must be a string or pathlib.PosixPath.')
 
         try:
             self.__parse_datastream()
@@ -237,15 +237,17 @@ class DatastreamParserARM:
             match = True
 
         if not match:
-            m = re.search(r'(^[a-z]{3})(\w+)$', tempstring[0])
+            m = re.search(r'(^[a-z]{3})([^A-Z]+)$', tempstring[0])
             if m is not None:
                 self.__site = m.group(1)
                 self.__class = m.group(2)
                 match = True
 
         if not match and len(tempstring[0]) == 3:
-            self.__site = tempstring[0]
-            match = True
+            m = re.search(r'(^[a-z]{3})', tempstring[0])
+            if m is not None:
+                self.__site = m.group(1)
+                match = True
 
         if not match:
             raise ValueError(self.__datastream)

--- a/act/utils/datetime_utils.py
+++ b/act/utils/datetime_utils.py
@@ -267,7 +267,7 @@ def adjust_timestamp(ds, time_bounds='time_bounds', align='left', offset=None):
                 for t in time_bounds
             ]
         else:
-            raise ValueError('Align should be set to one of [left, right, middle]')
+            raise ValueError('Align should be set to one of [left, right, center]')
 
     elif offset is not None:
         time = ds['time'].values
@@ -275,6 +275,7 @@ def adjust_timestamp(ds, time_bounds='time_bounds', align='left', offset=None):
     else:
         raise ValueError('time_bounds variable is not available')
 
+    time_start = np.array(time_start).astype('datetime64[ns]')
     ds = ds.assign_coords({'time': time_start})
 
     return ds

--- a/tests/utils/test_data_utils.py
+++ b/tests/utils/test_data_utils.py
@@ -348,7 +348,7 @@ def test_height_adjusted_pressure():
 
 
 def test_datastreamparser():
-    test_values = [1234, 4321.0, True, ['sgpmetE13.b1'], ('sgpmetE13.b1', )]
+    test_values = [1234, 4321.0, True, ['sgpmetE13.b1'], ('sgpmetE13.b1',)]
     for test_value in test_values:
         pytest.raises(ValueError, DatastreamParser, test_value)
 
@@ -466,11 +466,17 @@ def test_datastreamparser():
     assert fn_obj.time == '987654321'
     assert fn_obj.ext == 'superlong'
 
-    values = ['', ' ', 'sg', 'SGP', 'SGPMETE13.B1',
-              Path('zzzasoinfaoianasdfkansfaiZ999.z1.123456789.987654321.superlong'),
-              Path('/data/not/a/real/path/AsgpmetE13.b1.20190501.024254.nc'),
-              '/data/not/a/real/path/AsgpmetE13.b1.20190501.024254.nc',
-              'zzzasoinfaoianasdfkansfaiZ999.z1.123456789.987654321.superlong']
+    values = [
+        '',
+        ' ',
+        'sg',
+        'SGP',
+        'SGPMETE13.B1',
+        Path('zzzasoinfaoianasdfkansfaiZ999.z1.123456789.987654321.superlong'),
+        Path('/data/not/a/real/path/AsgpmetE13.b1.20190501.024254.nc'),
+        '/data/not/a/real/path/AsgpmetE13.b1.20190501.024254.nc',
+        'zzzasoinfaoianasdfkansfaiZ999.z1.123456789.987654321.superlong'
+    ]
     for value in values:
         fn_obj = DatastreamParser(value)
         assert fn_obj.site is None

--- a/tests/utils/test_data_utils.py
+++ b/tests/utils/test_data_utils.py
@@ -475,7 +475,7 @@ def test_datastreamparser():
         Path('zzzasoinfaoianasdfkansfaiZ999.z1.123456789.987654321.superlong'),
         Path('/data/not/a/real/path/AsgpmetE13.b1.20190501.024254.nc'),
         '/data/not/a/real/path/AsgpmetE13.b1.20190501.024254.nc',
-        'zzzasoinfaoianasdfkansfaiZ999.z1.123456789.987654321.superlong'
+        'zzzasoinfaoianasdfkansfaiZ999.z1.123456789.987654321.superlong',
     ]
     for value in values:
         fn_obj = DatastreamParser(value)


### PR DESCRIPTION
Updating DatastreamParserACT to accept pathlib.PosixPath as well as string paths. Fixing a few datetime64 calls to remove warnings during testing.

- [X ] Tests added
- [ X] Documentation reflects changes
- [ X] PEP8 Standards or use of linter
