### PR TITLE
FIX: Small error in Doppler lidar code with undefined var_name

### DIFF
--- a/act/retrievals/doppler_lidar.py
+++ b/act/retrievals/doppler_lidar.py
@@ -103,6 +103,7 @@ def compute_winds_from_ppi(
     else:
         try:
             snr = ds[snr_name].values
+            var_name = snr_name
         except KeyError:
             intensity = ds['intensity'].values
             snr = intensity - 1


### PR DESCRIPTION
The VAD code would not work if only signal_to_noise_ratio was defined and intensity was set to None due to an undefined variable name. This remedies this by pointing the var_name to be the snr_name which is only used to get the height_name.