### PR TITLE
ENH: Check for ER codes and strings.

### DIFF
--- a/act/utils/inst_utils.py
+++ b/act/utils/inst_utils.py
@@ -140,6 +140,10 @@ def decode_present_weather(ds, variable=None, decoded_name=None):
     # Get data and fill nans with -9999
     data = ds[variable]
     data = data.fillna(-9999)
+    data.values[data.values == 'ER'] = -9999
+
+    # Check if string codes instead of ints
+    data = data.astype('int64')
 
     # Get the weather type for each code
     wx_type = [weather[d] for d in data.values]


### PR DESCRIPTION
After discussion with Matt, there seems to be another error code present in the present weather code set called 'ER' this change will check for that as well as changes in dtype for the weather codes, such as string '00' instead of expected int 0