### PR TITLE
Correctly set movie duration for conversion

### DIFF
--- a/act/tests/sample_files.py
+++ b/act/tests/sample_files.py
@@ -8,6 +8,7 @@ be used for testing ACT.
 from arm_test_data import DATASETS
 
 # Single files
+EXAMPLE_MPEG = DATASETS.fetch('nsacamskyradmovieC1.a1.20240401.100300.mpg')
 EXAMPLE_MET1 = DATASETS.fetch('sgpmetE13.b1.20190101.000000.cdf')
 EXAMPLE_MET_SAIL = DATASETS.fetch('gucmetM1.b1.20230301.000000.cdf')
 EXAMPLE_MET_CSV = DATASETS.fetch('sgpmetE13.b1.20210401.000000.csv')

--- a/act/utils/io_utils.py
+++ b/act/utils/io_utils.py
@@ -10,7 +10,6 @@ import types
 try:
     import moviepy.editor as moviepy_editor
     import moviepy.video.io.ImageSequenceClip
-    from moviepy.video.io.VideoFileClip import VideoFileClip
 
     MOVIEPY_AVAILABLE = True
 except (ImportError, RuntimeError):
@@ -346,10 +345,11 @@ def generate_movie(images, write_filename=None, fps=10, **kwargs):
             if Path(images).suffix == '.mpg':
                 import numpy as np
                 import warnings
+
                 with warnings.catch_warnings():
                     warnings.filterwarnings('ignore', category=UserWarning)
                     frame = None
-                    duration = 0.  # Duration of movie in seconds
+                    duration = 0.0  # Duration of movie in seconds
                     while True:
                         result = clip.get_frame(duration)
                         if frame is not None and np.all(frame == result):

--- a/tests/utils/test_io_utils.py
+++ b/tests/utils/test_io_utils.py
@@ -275,5 +275,13 @@ def test_generate_movie():
             assert Path(result).name == write_filename
             assert np.isclose(Path(result).stat().st_size, 173189, 1000)
 
+            # Test converting MPEG to mp4
+            write_filename = 'movie3.mp4'
+            mpeg_file = sample_files.EXAMPLE_MPEG
+            result = act.utils.generate_movie(mpeg_file, write_filename=write_filename)
+            files = list(Path().glob(write_filename))
+            assert len(files) == 1
+            assert np.isclose(files[0].stat().st_size, 1625298, rtol=100, atol=100)
+
         finally:
             chdir(cwd)


### PR DESCRIPTION
generate_movie() uses moviepy to convert a mpg to other format. If the mpg movie does not have duration parameter set moviepy will guess incorrectly and the converted movie is too short. Adding code to loop through mpg movie to get correct duration for conversion.

- [ X] Tests added
- [X ] Documentation reflects changes
- [ X] PEP8 Standards or use of linter
- [ X] Xarray Dataset or DataArray variable naming follows 'ds' or 'da' naming
