### PR TITLE
Bug in a link for the eclipse blog post

### DIFF
--- a/docs/source/blog_posts/2024/2024_Eclipse_SGP.ipynb
+++ b/docs/source/blog_posts/2024/2024_Eclipse_SGP.ipynb
@@ -357,6 +357,8 @@
   }
  ],
  "metadata": {
+  "author": "Adam Theisen",
+  "date": "2024-04-15",
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/docs/source/blog_posts/2024/2024_Eclipse_SGP.ipynb
+++ b/docs/source/blog_posts/2024/2024_Eclipse_SGP.ipynb
@@ -373,7 +373,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.5"
-  }
+  },
+  "tags": "eclipse,SGP,DL,RWP,MET,SIRS,ECOR,SMPS,CPCUF",
+  "title": "Exploration of data from the 2024 eclipse at SGP"
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/docs/source/blog_posts/2024/2024_Eclipse_SGP.ipynb
+++ b/docs/source/blog_posts/2024/2024_Eclipse_SGP.ipynb
@@ -344,7 +344,7 @@
     "\n",
     "Data from the ultrafine condensation particle counter (CPCUF; panel 6) and the scanning mobility particle sizer (SMPS; panel 7) were included to see if there was a burst in new particle formation (NPF) once photochemical activity started back up.  While there is a second peak in the size distribution post eclipse, it cannot be concluded that it was related.  The mentor, Ashish Singh, had noted \"In springtime at SGP, there's a recurring and/or a particle burst, which appears to be regional (based on published papers). Typically, it initiates around 16:00 UTC or later consistently, coinciding with the timeframe of a solar eclipse (17:30-20:00 UTC and beyond) on April 08. Analyzing the data from nSMPS and SMPS size distribution timeseries, it's unclear whether the fluctuations in solar insolation during the eclipse are directly linked to the onset of the burst or formation event, especially concerning particles below 50 nm.\"\n",
     "\n",
-    "There's a lot of interesting data to explore from the eclipse.  You can learn more about ARM's instruments and data by visiting [ARM's website.](www.arm.gov)\n",
+    "There's a lot of interesting data to explore from the eclipse.  You can learn more about ARM's instruments and data by visiting [ARM's website.](https://arm.gov/)\n",
     "\n",
     "Thank you to the ARM staff that helped contribute ideas and feedback to this blog post.\n",
     "* Max Grover\n",
@@ -354,6 +354,14 @@
     "* Paytsar Muradyan\n",
     "* Jenni Kyrouac"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f5dc51b-c3af-4fdb-9e34-91f52582cedc",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
<!-- Please remove check-list items that aren't relevant to your changes -->

- [x] Documentation reflects changes
- [x] PEP8 Standards or use of linter
- [x] Xarray Dataset or DataArray variable naming follows 'ds' or 'da' naming
