### PR TITLE
Fix HYSPLIT reader to adjust for an arbitrary number of trajectories.

### DIFF
--- a/act/io/hysplit.py
+++ b/act/io/hysplit.py
@@ -35,8 +35,12 @@ def read_hysplit(filename, base_year=2000):
             num_lines += 1
             grid_names.append(data[0])
             grid_times.append(
-                datetime(year=(int(data[1])+ base_year),
-                          month=int(data[2]), day=int(data[3]), hour=int(data[4]))
+                datetime(
+                    year=(int(data[1]) + base_year),
+                    month=int(data[2]),
+                    day=int(data[3]),
+                    hour=int(data[4]),
+                )
             )
             forecast_hours[i] = int(data[5])
         ds["grid_forecast_hour"] = xr.DataArray(forecast_hours, dims=["num_grids"])
@@ -96,8 +100,7 @@ def read_hysplit(filename, base_year=2000):
             var_list.append(variable)
 
         input_df = pd.read_csv(
-            filebuf, sep=r'\s+', index_col=False, names=var_list, 
-            skiprows=1
+            filebuf, sep=r'\s+', index_col=False, names=var_list, skiprows=1
         )  # noqa W605
         input_df['year'] = base_year + input_df['year']
         input_df['year'] = input_df['year'].astype(int)

--- a/act/io/hysplit.py
+++ b/act/io/hysplit.py
@@ -35,7 +35,8 @@ def read_hysplit(filename, base_year=2000):
             num_lines += 1
             grid_names.append(data[0])
             grid_times.append(
-                datetime(year=int(data[1]), month=int(data[2]), day=int(data[3]), hour=int(data[4]))
+                datetime(year=(int(data[1])+ base_year),
+                          month=int(data[2]), day=int(data[3]), hour=int(data[4]))
             )
             forecast_hours[i] = int(data[5])
         ds["grid_forecast_hour"] = xr.DataArray(forecast_hours, dims=["num_grids"])
@@ -94,31 +95,37 @@ def read_hysplit(filename, base_year=2000):
         for variable in data[1:]:
             var_list.append(variable)
 
-    input_df = pd.read_csv(
-        filename, sep=r'\s+', index_col=False, names=var_list, skiprows=12
-    )  # noqa W605
-    input_df['year'] = base_year + input_df['year']
-    input_df['time'] = pd.to_datetime(
-        input_df[["year", "month", "day", "hour", "minute"]], format='%y%m%d%H%M'
-    )
-    input_df = input_df.set_index("time")
-    del input_df["year"]
-    del input_df["month"]
-    del input_df["day"]
-    del input_df["hour"]
-    del input_df["minute"]
-    ds = ds.merge(input_df.to_xarray())
-    ds.attrs['datastream'] = 'hysplit'
-    ds["trajectory_number"].attrs["standard_name"] = "Trajectory number"
-    ds["trajectory_number"].attrs["units"] = "1"
-    ds["grid_number"].attrs["standard_name"] = "Grid number"
-    ds["grid_number"].attrs["units"] = "1"
-    ds["age"].attrs["standard_name"] = "Grid number"
-    ds["age"].attrs["units"] = "1"
-    ds["lat"].attrs["standard_name"] = "Latitude"
-    ds["lat"].attrs["units"] = "degree"
-    ds["lon"].attrs["standard_name"] = "Longitude"
-    ds["lon"].attrs["units"] = "degree"
-    ds["alt"].attrs["standard_name"] = "Altitude"
-    ds["alt"].attrs["units"] = "meter"
+        input_df = pd.read_csv(
+            filebuf, sep=r'\s+', index_col=False, names=var_list, 
+            skiprows=1
+        )  # noqa W605
+        input_df['year'] = base_year + input_df['year']
+        input_df['year'] = input_df['year'].astype(int)
+        input_df['month'] = input_df['month'].astype(int)
+        input_df['day'] = input_df['day'].astype(int)
+        input_df['hour'] = input_df['hour'].astype(int)
+        input_df['minute'] = input_df['minute'].astype(int)
+        input_df['time'] = pd.to_datetime(
+            input_df[["year", "month", "day", "hour", "minute"]], format='%y%m%d%H%M'
+        )
+        input_df = input_df.set_index("time")
+        del input_df["year"]
+        del input_df["month"]
+        del input_df["day"]
+        del input_df["hour"]
+        del input_df["minute"]
+        ds = ds.merge(input_df.to_xarray())
+        ds.attrs['datastream'] = 'hysplit'
+        ds["trajectory_number"].attrs["standard_name"] = "Trajectory number"
+        ds["trajectory_number"].attrs["units"] = "1"
+        ds["grid_number"].attrs["standard_name"] = "Grid number"
+        ds["grid_number"].attrs["units"] = "1"
+        ds["age"].attrs["standard_name"] = "Grid number"
+        ds["age"].attrs["units"] = "1"
+        ds["lat"].attrs["standard_name"] = "Latitude"
+        ds["lat"].attrs["units"] = "degree"
+        ds["lon"].attrs["standard_name"] = "Longitude"
+        ds["lon"].attrs["units"] = "degree"
+        ds["alt"].attrs["standard_name"] = "Altitude"
+        ds["alt"].attrs["units"] = "meter"
     return ds

--- a/tests/io/test_hysplit.py
+++ b/tests/io/test_hysplit.py
@@ -12,5 +12,5 @@ def test_read_hysplit():
     assert 'PRESSURE' in ds.variables.keys()
     assert ds.sizes["num_grids"] == 8
     assert ds.sizes["num_trajectories"] == 1
-    assert ds.sizes['time'] == 121
+    assert ds.sizes['time'] == 120
     assert ds['age'].min() == -120


### PR DESCRIPTION
The HYSPLIT reader was assuming that the data started at line 13, which was breaking the reader when using other test files generated by students at the ARM Summer School. This now fixes that issue, making the HYSPLIT reader able to read files with an arbitrary number of trajectories.
- [x] PEP8 Standards or use of linter
- [x] Xarray Dataset or DataArray variable naming follows 'ds' or 'da' naming
