### PR TITLE
FIX: Wrong function name, causing ameriflux docs to not build.

### DIFF
--- a/act/io/__init__.py
+++ b/act/io/__init__.py
@@ -28,7 +28,7 @@ __getattr__, __dir__, __all__ = lazy.attach(
             'check_if_tar_gz_file',
             'read_arm_mmcr',
         ],
-        'ameriflux': ['format_as_ameriflux'],
+        'ameriflux': ['convert_to_ameriflux'],
         'text': ['read_csv'],
         'icartt': ['read_icartt'],
         'mpl': ['proc_sigma_mplv5_read', 'read_sigma_mplv5'],


### PR DESCRIPTION
<!-- Please remove check-list items that aren't relevant to your changes -->

- [ ] Closes #836
