### PR TITLE
Updates to making QC Summary files

### DIFF
--- a/act/io/arm.py
+++ b/act/io/arm.py
@@ -549,8 +549,9 @@ class WriteDataset:
         make_copy=True,
         cf_compliant=False,
         delete_global_attrs=['qc_standards_version', 'qc_method', 'qc_comment'],
-        FillValue=-9999,
+        FillValue=True,
         cf_convention='CF-1.8',
+        encoding={},
         **kwargs,
     ):
         """
@@ -573,7 +574,8 @@ class WriteDataset:
             white space between words.
         join_char : str
             The character sting to use for replacing white spaces between words when converting
-            a list of strings to single character string attributes.
+            a list of strings to single character string attributes. Main use is with the
+            flag_meanings attribute.
         make_copy : boolean
             Make a copy before modifying Dataset to write. For large Datasets this
             may add processing time and memory. If modifying the Dataset is OK
@@ -587,14 +589,18 @@ class WriteDataset:
             Optional global attributes to be deleted. Defaults to some standard
             QC attributes that are not needed. Can add more or set to None to not
             remove the attributes.
-        FillValue : int, float
-            The value to use as a _FillValue in output file. This is used to fix
-            issues with how Xarray handles missing_value upon reading. It's confusing
-            so not a perfect fix. Set to None to leave Xarray to do what it wants.
-            Set to a value to be the value used as _FillValue in the file and data
-            array. This should then remove missing_value attribute from the file as well.
+        FillValue : boolean
+            Xarray assumes all float type variables had the missing value indicator converted
+            to NaN upon reading. to_netcdf() will then write a _FillValue attribute set to NaN.
+            Set FillValue to False to supress adding the _FillValue=NaN variable attribute to
+            the written file. Set to True to allow to_netcdf() to add the attribute.
+            If the Dataset variable already has a _FillValue attribute or a _FillValue key
+            is provided in the encoding dictionary those will not be changed and a _FillValue
+            will be written to NetCDF file.
         cf_convention : str
             The Climate and Forecast convention string to add to Conventions attribute.
+        encoding : dict
+            The encoding dictionary used with to_netcdf() method.
         **kwargs : keywords
             Keywords to pass through to Dataset.to_netcdf()
 
@@ -607,105 +613,102 @@ class WriteDataset:
         """
 
         if make_copy:
-            write_ds = copy.deepcopy(self._ds)
+            ds = copy.deepcopy(self._ds)
         else:
-            write_ds = self._ds
+            ds = self._ds
 
-        encoding = {}
         if cleanup_global_atts:
-            for attr in list(write_ds.attrs):
+            for attr in list(ds.attrs):
                 if attr.startswith('_'):
-                    del write_ds.attrs[attr]
+                    del ds.attrs[attr]
 
         if cleanup_qc_atts:
             check_atts = ['flag_meanings', 'flag_assessments']
-            for var_name in list(write_ds.data_vars):
-                if 'standard_name' not in write_ds[var_name].attrs.keys():
+            for var_name in list(ds.data_vars):
+                if 'standard_name' not in ds[var_name].attrs.keys():
                     continue
 
-                if write_ds[var_name].attrs['standard_name'] != "quality_flag":
+                if ds[var_name].attrs['standard_name'] != "quality_flag":
                     continue
 
                 for attr_name in check_atts:
                     try:
-                        att_values = write_ds[var_name].attrs[attr_name]
+                        att_values = ds[var_name].attrs[attr_name]
                         if isinstance(att_values, (list, tuple)):
                             att_values = [
                                 att_value.replace(' ', join_char) for att_value in att_values
                             ]
-                            write_ds[var_name].attrs[attr_name] = ' '.join(att_values)
+                            ds[var_name].attrs[attr_name] = ' '.join(att_values)
 
                     except KeyError:
                         pass
 
-                # Tell .to_netcdf() to not add a _FillValue attribute for
-                # quality control variables.
-                if FillValue is not False:
-                    encoding[var_name] = {'_FillValue': None}
-
-        # Clean up _FillValue vs missing_value mess by creating an
-        # encoding dictionary with each variable's _FillValue set to
-        # requested fill value. May need to improve upon this for data type
-        # and other issues in the future.
-        if FillValue is not False:
-            for var_name in list(write_ds.data_vars):
-                if '_FillValue' in write_ds[var_name].attrs:
+        # Xarray makes an assumption that float type variables were read in and converted
+        # missing value indicator to NaN. .to_netcdf() will then automatically assign
+        # _FillValue attribute set to NaN when writing. If requested will set _FillValue
+        # key in encoding to None which will supress to_netcdf() from adding a _FillValue.
+        # If _FillValue attribute or _FillValue key in encoding is already set, will not
+        # override and the _FillValue will be written to the file.
+        if not FillValue:
+            all_var_names = list(ds.coords.keys()) + list(ds.data_vars)
+            for var_name in all_var_names:
+                if '_FillValue' in ds[var_name].attrs:
                     continue
 
                 if var_name not in encoding.keys():
-                    encoding[var_name] = {'_FillValue': FillValue}
+                    encoding[var_name] = {'_FillValue': None}
                 elif '_FillValue' not in encoding[var_name].keys():
-                    encoding[var_name] = {'_FillValue': FillValue}
+                    encoding[var_name]['_FillValue'] = None
 
         if delete_global_attrs is not None:
             for attr in delete_global_attrs:
                 try:
-                    del write_ds.attrs[attr]
+                    del ds.attrs[attr]
                 except KeyError:
                     pass
 
-        for var_name in list(write_ds.keys()):
-            if 'string' in list(write_ds[var_name].attrs.keys()):
-                att = write_ds[var_name].attrs['string']
-                write_ds[var_name].attrs[var_name + '_string'] = att
-                del write_ds[var_name].attrs['string']
+        for var_name in list(ds.keys()):
+            if 'string' in list(ds[var_name].attrs.keys()):
+                att = ds[var_name].attrs['string']
+                ds[var_name].attrs[var_name + '_string'] = att
+                del ds[var_name].attrs['string']
 
         # If requested update global attributes and variables attributes for required
         # CF attributes.
         if cf_compliant:
             # Get variable names and standard name for each variable
-            var_names = list(write_ds.keys())
+            var_names = list(ds.keys())
             standard_names = []
             for var_name in var_names:
                 try:
-                    standard_names.append(write_ds[var_name].attrs['standard_name'])
+                    standard_names.append(ds[var_name].attrs['standard_name'])
                 except KeyError:
                     standard_names.append(None)
 
             # Check if time varible has axis and standard_name attribute
             coord_name = 'time'
             try:
-                write_ds[coord_name].attrs['axis']
+                ds[coord_name].attrs['axis']
             except KeyError:
                 try:
-                    write_ds[coord_name].attrs['axis'] = 'T'
+                    ds[coord_name].attrs['axis'] = 'T'
                 except KeyError:
                     pass
 
             try:
-                write_ds[coord_name].attrs['standard_name']
+                ds[coord_name].attrs['standard_name']
             except KeyError:
                 try:
-                    write_ds[coord_name].attrs['standard_name'] = 'time'
+                    ds[coord_name].attrs['standard_name'] = 'time'
                 except KeyError:
                     pass
 
             # Try to determine type of dataset by coordinate dimention named time
             # and other factors
             try:
-                write_ds.attrs['FeatureType']
+                ds.attrs['FeatureType']
             except KeyError:
-                dim_names = list(write_ds.dims)
+                dim_names = list(ds.dims)
                 FeatureType = None
                 if dim_names == ['time']:
                     FeatureType = 'timeSeries'
@@ -713,15 +716,15 @@ class WriteDataset:
                     FeatureType = 'timeSeries'
                 elif len(dim_names) >= 2 and 'time' in dim_names:
                     for var_name in var_names:
-                        dims = list(write_ds[var_name].dims)
+                        dims = list(ds[var_name].dims)
                         if len(dims) == 2 and 'time' in dims:
                             prof_dim = list(set(dims) - {'time'})[0]
-                            if write_ds[prof_dim].values.size > 2:
+                            if ds[prof_dim].values.size > 2:
                                 FeatureType = 'timeSeriesProfile'
                                 break
 
                 if FeatureType is not None:
-                    write_ds.attrs['FeatureType'] = FeatureType
+                    ds.attrs['FeatureType'] = FeatureType
 
             # Add axis and positive attributes to variables with standard_name
             # equal to 'altitude'
@@ -730,18 +733,18 @@ class WriteDataset:
             ]
             for var_name in alt_variables:
                 try:
-                    write_ds[var_name].attrs['axis']
+                    ds[var_name].attrs['axis']
                 except KeyError:
-                    write_ds[var_name].attrs['axis'] = 'Z'
+                    ds[var_name].attrs['axis'] = 'Z'
 
                 try:
-                    write_ds[var_name].attrs['positive']
+                    ds[var_name].attrs['positive']
                 except KeyError:
-                    write_ds[var_name].attrs['positive'] = 'up'
+                    ds[var_name].attrs['positive'] = 'up'
 
             # Check if the Conventions global attribute lists the CF convention
             try:
-                Conventions = write_ds.attrs['Conventions']
+                Conventions = ds.attrs['Conventions']
                 Conventions = Conventions.split()
                 cf_listed = False
                 for ii in Conventions:
@@ -750,43 +753,30 @@ class WriteDataset:
                         break
                 if not cf_listed:
                     Conventions.append(cf_convention)
-                write_ds.attrs['Conventions'] = ' '.join(Conventions)
+                ds.attrs['Conventions'] = ' '.join(Conventions)
 
             except KeyError:
-                write_ds.attrs['Conventions'] = str(cf_convention)
+                ds.attrs['Conventions'] = str(cf_convention)
 
             # Reorder global attributes to ensure history is last
             try:
-                history = copy.copy(write_ds.attrs['history'])
-                del write_ds.attrs['history']
-                write_ds.attrs['history'] = history
+                history = copy.copy(ds.attrs['history'])
+                del ds.attrs['history']
+                ds.attrs['history'] = history
             except KeyError:
                 pass
-        current_time = dt.datetime.now().replace(microsecond=0)
-        if 'history' in list(write_ds.attrs.keys()):
-            write_ds.attrs['history'] += ''.join(
-                [
-                    '\n',
-                    str(current_time),
-                    ' created by ACT ',
-                    str(act.__version__),
-                    ' act.io.write.write_netcdf',
-                ]
-            )
 
-        # Correct time variable from having a _FillValue attribute written to the file.
-        try:
-            if 'time' not in encoding.keys():
-                encoding['time'] = {}
+        current_time = dt.datetime.utcnow().replace(microsecond=0)
+        history_value = (
+            f'Written to file by ACT-{act.__version__} '
+            f'with write_netcdf() at {current_time} UTC'
+        )
+        if 'history' in list(ds.attrs.keys()):
+            ds.attrs['history'] += f" ; {history_value}"
+        else:
+            ds.attrs['history'] = history_value
 
-            encoding['time']['_FillValue'] = None
-        except KeyError:
-            pass
-
-        if hasattr(write_ds, 'time_bounds') and not write_ds.time.encoding:
-            write_ds.time.encoding.update(write_ds.time_bounds.encoding)
-
-        write_ds.to_netcdf(encoding=encoding, **kwargs)
+        ds.to_netcdf(encoding=encoding, **kwargs)
 
 
 def check_if_tar_gz_file(filenames):

--- a/act/qc/arm.py
+++ b/act/qc/arm.py
@@ -213,7 +213,7 @@ def add_dqr_to_qc(
             if skip_location_vars and var_name in loc_vars:
                 continue
 
-            # Do not process time varibles
+            # Do not process time variables
             if var_name in ['time', 'time_offset', 'time_bounds']:
                 continue
 

--- a/act/qc/arm.py
+++ b/act/qc/arm.py
@@ -71,7 +71,7 @@ def add_dqr_to_qc(
         Does not apply DQRs to location variables.  This can be useful in the event
         the submitter has erroneously selected all variables.
     create_missing_qc_variables : boolean
-        If a quality control varible for the data varialbe does not exist,
+        If a quality control variable for the data variable does not exist,
         create the quality control varible and apply DQR.
 
     Returns

--- a/act/qc/arm.py
+++ b/act/qc/arm.py
@@ -181,6 +181,10 @@ def add_dqr_to_qc(
             if skip_location_vars and var_name in loc_vars:
                 continue
 
+            # Do not process time varibles
+            if var_name in ['time', 'time_offset']:
+                continue
+
             # Only process provided variable names
             if variable is not None and var_name not in variable:
                 continue

--- a/act/qc/arm.py
+++ b/act/qc/arm.py
@@ -111,7 +111,7 @@ def add_dqr_to_qc(
     time = ds['time'].values
 
     # If the time is not a datetime64 because the read routine was not asked to
-    # convert CF variables, convert the time varible for this routine only.
+    # convert CF variables, convert the time variable for this routine only.
     if not np.issubdtype(time.dtype, np.datetime64):
         units_strings = [
             'seconds since ',

--- a/act/qc/arm.py
+++ b/act/qc/arm.py
@@ -134,8 +134,8 @@ def add_dqr_to_qc(
         start_time = np.datetime64(start_time, td64_string)
         time = start_time + ds['time'].values.astype('timedelta64[s]')
 
-    start_date = time[0].astype(dt.datetime).strftime('%Y%m%d')
-    end_date = time[-1].astype(dt.datetime).strftime('%Y%m%d')
+    start_date = time[0].astype('datetime64[s]').astype(dt.datetime).strftime('%Y%m%d')
+    end_date = time[-1].astype('datetime64[s]').astype(dt.datetime).strftime('%Y%m%d')
 
     # Clean up assessment to ensure it is a string with no spaces.
     if isinstance(assessment, (list, tuple)):

--- a/act/qc/clean.py
+++ b/act/qc/clean.py
@@ -792,7 +792,8 @@ class CleanDataset:
         self,
         variables=None,
         exclude_variables=None,
-        qc_lookup={'Incorrect': 'Bad', 'Suspect': 'Indeterminate'},
+        # qc_lookup={'Incorrect': 'Bad', 'Suspect': 'Indeterminate'},
+        qc_lookup={'Bad': 'Incorrect', 'Indeterminate': 'Suspect'},
     ):
         """
         Method to clean up assessment terms used to be consistent between

--- a/act/qc/clean.py
+++ b/act/qc/clean.py
@@ -792,7 +792,6 @@ class CleanDataset:
         self,
         variables=None,
         exclude_variables=None,
-        # qc_lookup={'Incorrect': 'Bad', 'Suspect': 'Indeterminate'},
         qc_lookup={'Bad': 'Incorrect', 'Indeterminate': 'Suspect'},
     ):
         """

--- a/act/qc/qc_summary.py
+++ b/act/qc/qc_summary.py
@@ -121,7 +121,6 @@ class QCSummary:
                 )
 
                 # # Do not really know how to handle scalars yet.
-                #     warnings.warn(f'Unable to process scalar variable {var_name}. '
                 #                   'Scalar variables currently not implemented.')
                 #     continue
 

--- a/act/qc/qc_summary.py
+++ b/act/qc/qc_summary.py
@@ -25,7 +25,10 @@ class QCSummary:
         self._ds = ds
 
     def create_qc_summary(
-        self, cleanup_qc=False, remove_attrs=['fail_min', 'fail_max', 'fail_delta']
+        self,
+        cleanup_qc=False,
+        remove_attrs=['fail_min', 'fail_max', 'fail_delta'],
+        normalize_assessment=True,
     ):
         """
         Method to convert embedded quality control to summary QC that utilzes
@@ -39,6 +42,9 @@ class QCSummary:
             control variables to use ACT standards.
         remove_attrs : None, list
             Quality Control variable attributes to remove after creating the summary.
+        normalize_assessment : bool
+            Option to clean up assessments to use the same terminology.
+
 
         Returns
         -------
@@ -62,6 +68,9 @@ class QCSummary:
 
         if cleanup_qc:
             self._ds.clean.cleanup()
+
+        if normalize_assessment:
+            self._ds.clean.normalize_assessment()
 
         return_ds = self._ds.copy()
 

--- a/act/qc/qc_summary.py
+++ b/act/qc/qc_summary.py
@@ -121,7 +121,6 @@ class QCSummary:
                 )
 
                 # # Do not really know how to handle scalars yet.
-                # if return_ds[var_name].ndim == 0:
                 #     warnings.warn(f'Unable to process scalar variable {var_name}. '
                 #                   'Scalar variables currently not implemented.')
                 #     continue

--- a/act/qc/qc_summary.py
+++ b/act/qc/qc_summary.py
@@ -121,7 +121,6 @@ class QCSummary:
                 )
 
                 # # Do not really know how to handle scalars yet.
-                #     continue
 
                 return_ds.qcfilter.add_test(
                     var_name,

--- a/act/qc/qc_summary.py
+++ b/act/qc/qc_summary.py
@@ -121,7 +121,6 @@ class QCSummary:
                 )
 
                 # # Do not really know how to handle scalars yet.
-                #                   'Scalar variables currently not implemented.')
                 #     continue
 
                 return_ds.qcfilter.add_test(

--- a/act/qc/qc_summary.py
+++ b/act/qc/qc_summary.py
@@ -9,6 +9,8 @@ description.
 
 import datetime
 import copy
+import xarray as xr
+import warnings
 
 
 class QCSummary:
@@ -53,18 +55,12 @@ class QCSummary:
 
         """
 
-        standard_assessments = [
-            'Suspect',
-            'Indeterminate',
-            'Incorrect',
-            'Bad',
-        ]
-        standard_meanings = [
-            "Data suspect further analysis recommended",
-            "Data suspect further analysis recommended",
-            "Data incorrect use not recommended",
-            "Data incorrect use not recommended",
-        ]
+        standard_meanings = {
+            'Suspect': "Data suspect further analysis recommended",
+            'Indeterminate': "Data suspect further analysis recommended",
+            'Incorrect': "Data incorrect use not recommended",
+            'Bad': "Data incorrect use not recommended",
+        }
 
         if cleanup_qc:
             self._ds.clean.cleanup()
@@ -81,11 +77,15 @@ class QCSummary:
             if qc_var_name is None:
                 continue
 
+            # Do not really know how to handle scalars yet.
+            if return_ds[qc_var_name].ndim == 0:
+                warnings.warn(
+                    f'Unable to process scalar variable {var_name}. '
+                    'Scalar variables currently not implemented.'
+                )
+                continue
+
             added = True
-
-            assessments = list(set(self._ds[qc_var_name].attrs['flag_assessments']))
-
-            import xarray as xr
 
             result = xr.zeros_like(return_ds[qc_var_name])
             for attr in ['flag_masks', 'flag_meanings', 'flag_assessments', 'flag_values']:
@@ -105,22 +105,31 @@ class QCSummary:
                 flag_value=True,
             )
 
-            for ii, assessment in enumerate(standard_assessments):
-                if assessment not in assessments:
-                    continue
+            flag_assessments = list(standard_meanings.keys())
+            added_assessments = set(self._ds[qc_var_name].attrs['flag_assessments']) - set(
+                flag_assessments
+            )
+            flag_assessments += list(added_assessments)
+            for ii, assessment in enumerate(flag_assessments):
+                try:
+                    standard_meaning = standard_meanings[assessment.capitalize()]
+                except KeyError:
+                    standard_meaning = f"Data {assessment}"
 
                 qc_mask = self.get_masked_data(
                     var_name, rm_assessments=assessment, return_mask_only=True
                 )
 
-                # Do not really know how to handle scalars yet.
-                if qc_mask.ndim == 0:
-                    continue
+                # # Do not really know how to handle scalars yet.
+                # if return_ds[var_name].ndim == 0:
+                #     warnings.warn(f'Unable to process scalar variable {var_name}. '
+                #                   'Scalar variables currently not implemented.')
+                #     continue
 
                 return_ds.qcfilter.add_test(
                     var_name,
                     index=qc_mask,
-                    test_meaning=standard_meanings[ii],
+                    test_meaning=standard_meaning,
                     test_assessment=assessment,
                     flag_value=True,
                 )

--- a/act/qc/qc_summary.py
+++ b/act/qc/qc_summary.py
@@ -60,10 +60,10 @@ class QCSummary:
             "Data incorrect use not recommended",
         ]
 
-        return_ds = self._ds.copy()
-
         if cleanup_qc:
-            return_ds.clean.cleanup()
+            self._ds.clean.cleanup()
+
+        return_ds = self._ds.copy()
 
         added = False
         for var_name in list(self._ds.data_vars):
@@ -121,6 +121,8 @@ class QCSummary:
                 for att_name in copy.copy(list(return_ds[qc_var_name].attrs.keys())):
                     if att_name in remove_attrs:
                         del return_ds[qc_var_name].attrs[att_name]
+
+            self._ds.update({qc_var_name: return_ds[qc_var_name]})
 
         if added:
             from act import __version__ as version

--- a/tests/discovery/test_asos.py
+++ b/tests/discovery/test_asos.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-
+import pytest
 import numpy as np
 
 import act
@@ -22,6 +22,9 @@ def test_get_region():
     time_window = [datetime(2020, 2, 4, 2, 0), datetime(2020, 2, 12, 10, 0)]
     lat_window = (41.8781 - 0.5, 41.8781 + 0.5)
     lon_window = (-87.6298 - 0.5, -87.6298 + 0.5)
-    my_asoses = act.discovery.get_asos_data(time_window, lat_range=lat_window, lon_range=lon_window)
+    with pytest.warns(UserWarning, match="No data available at station"):
+        my_asoses = act.discovery.get_asos_data(
+            time_window, lat_range=lat_window, lon_range=lon_window
+        )
     asos_keys = list(my_asoses.keys())
     assert asos_keys == my_keys

--- a/tests/io/test_ameriflux.py
+++ b/tests/io/test_ameriflux.py
@@ -1,13 +1,15 @@
 import act
 import glob
 import xarray as xr
+import pytest
 
 
 def test_convert_to_ameriflux():
     files = glob.glob(act.tests.sample_files.EXAMPLE_ECORSF_E39)
     ds_ecor = act.io.arm.read_arm_netcdf(files)
 
-    df = act.io.ameriflux.convert_to_ameriflux(ds_ecor)
+    with pytest.warns(UserWarning, match="mapping was not provided"):
+        df = act.io.ameriflux.convert_to_ameriflux(ds_ecor)
 
     assert 'FC' in df
     assert 'WS_MAX' in df
@@ -16,7 +18,8 @@ def test_convert_to_ameriflux():
     ds_sebs = act.io.arm.read_arm_netcdf(files)
 
     ds = xr.merge([ds_ecor, ds_sebs])
-    df = act.io.ameriflux.convert_to_ameriflux(ds)
+    with pytest.warns(UserWarning, match="mapping was not provided"):
+        df = act.io.ameriflux.convert_to_ameriflux(ds)
 
     assert 'SWC_2_1_1' in df
     assert 'TS_3_1_1' in df
@@ -26,7 +29,8 @@ def test_convert_to_ameriflux():
     ds_stamp = act.io.arm.read_arm_netcdf(files)
 
     ds = xr.merge([ds_ecor, ds_sebs, ds_stamp], compat='override')
-    df = act.io.ameriflux.convert_to_ameriflux(ds)
+    with pytest.warns(UserWarning, match="mapping was not provided"):
+        df = act.io.ameriflux.convert_to_ameriflux(ds)
 
     assert 'SWC_6_10_1' in df
     assert 'G_2_1_1' in df

--- a/tests/plotting/test_distributiondisplay.py
+++ b/tests/plotting/test_distributiondisplay.py
@@ -419,7 +419,12 @@ def test_plot_pie_chart():
     ds = act.io.arm.read_arm_netcdf(sample_files.EXAMPLE_AOSACSM)
     fields = ['sulfate', 'ammonium', 'nitrate', 'chloride']
     display = DistributionDisplay(ds)
-    display.plot_pie_chart(fields)
+    with pytest.warns(UserWarning, match="contains negatives values, consider using a threshold."):
+        with pytest.warns(
+            UserWarning,
+            match="No time parameter used, calculating a mean for each field for the whole dataset.",
+        ):
+            display.plot_pie_chart(fields)
     ds.close()
 
     try:
@@ -435,12 +440,16 @@ def test_plot_pie_chart_kwargs():
     threshold = 0.0
     fill_value = 0.0
     display = DistributionDisplay(ds)
-    display.plot_pie_chart(
-        fields,
-        threshold=threshold,
-        fill_value=fill_value,
-        colors=['olivedrab', 'rosybrown', 'gray', 'saddlebrown'],
-    )
+    with pytest.warns(
+        UserWarning,
+        match="No time parameter used, calculating a mean for each field for the whole dataset.",
+    ):
+        display.plot_pie_chart(
+            fields,
+            threshold=threshold,
+            fill_value=fill_value,
+            colors=['olivedrab', 'rosybrown', 'gray', 'saddlebrown'],
+        )
     ds.close()
 
     try:

--- a/tests/plotting/test_skewtdisplay.py
+++ b/tests/plotting/test_skewtdisplay.py
@@ -67,7 +67,8 @@ def test_multi_skewt_plot():
 def test_enhanced_skewt_plot():
     ds = act.io.arm.read_arm_netcdf(sample_files.EXAMPLE_SONDE1)
     display = act.plotting.SkewTDisplay(ds)
-    display.plot_enhanced_skewt(color_field='alt', component_range=85)
+    with pytest.warns():
+        display.plot_enhanced_skewt(color_field='alt', component_range=85)
     ds.close()
     return display.fig
 

--- a/tests/plotting/test_timeseriesdisplay.py
+++ b/tests/plotting/test_timeseriesdisplay.py
@@ -462,7 +462,8 @@ def test_plot_barbs_from_u_v4():
     fake_ds = xr.Dataset(
         {'xbins': xbins, 'ybins': ybins, 'ydata': y_array, 'xdata': x_array, 'pres': pres}
     )
-    BarbDisplay = TimeSeriesDisplay(fake_ds)
+    with pytest.warns(UserWarning, match="Could not discern datastreamname and dict or tuple"):
+        BarbDisplay = TimeSeriesDisplay(fake_ds)
     BarbDisplay.plot_barbs_from_u_v(
         'xdata', 'ydata', None, set_title='test', use_var_for_y='pres', cmap='jet'
     )
@@ -488,7 +489,8 @@ def test_plot_barbs_from_u_v5():
     fake_ds = xr.Dataset(
         {'xbins': xbins, 'ybins': ybins, 'ydata': y_array, 'xdata': x_array, 'pres': pres}
     )
-    BarbDisplay = TimeSeriesDisplay(fake_ds)
+    with pytest.warns(UserWarning, match="Could not discern datastreamname and dict or tuple"):
+        BarbDisplay = TimeSeriesDisplay(fake_ds)
     BarbDisplay.plot_barbs_from_u_v(
         'xdata',
         'ydata',

--- a/tests/plotting/test_windrosedisplay.py
+++ b/tests/plotting/test_windrosedisplay.py
@@ -138,15 +138,16 @@ def test_groupby_plot():
     # Create Plot Display
     display = WindRoseDisplay(ds, figsize=(15, 15), subplot_shape=(3, 3))
     groupby = display.group_by('day')
-    groupby.plot_group(
-        'plot_data',
-        None,
-        dir_field='wdir_vec_mean',
-        spd_field='wspd_vec_mean',
-        data_field='temp_mean',
-        num_dirs=12,
-        plot_type='line',
-    )
+    with pytest.warns(RuntimeWarning):
+        groupby.plot_group(
+            'plot_data',
+            None,
+            dir_field='wdir_vec_mean',
+            spd_field='wspd_vec_mean',
+            data_field='temp_mean',
+            num_dirs=12,
+            plot_type='line',
+        )
 
     # Set theta tick markers for each axis inside display to be inside the polar axes
     for i in range(3):

--- a/tests/plotting/test_xsectiondisplay.py
+++ b/tests/plotting/test_xsectiondisplay.py
@@ -57,7 +57,11 @@ def test_xsection_plot_map():
         sample_files.EXAMPLE_VISST, combine='nested', concat_dim='time'
     )
     try:
-        xsection = XSectionDisplay(radar_ds, figsize=(15, 8))
+        with pytest.warns(
+            UserWarning,
+            match="Could not discern datastreamname and dict or tuple were not provided. Using defaultname of act_datastream!",
+        ):
+            xsection = XSectionDisplay(radar_ds, figsize=(15, 8))
         xsection.plot_xsection_map(
             None,
             'ir_temperature',

--- a/tests/qc/test_qc_summary.py
+++ b/tests/qc/test_qc_summary.py
@@ -38,10 +38,10 @@ def test_qc_summary():
 
             assert np.sum(result[qc_var_name].values) == 610
 
-            qc_ma = result.qcfilter.get_masked_data(var_name, rm_assessments='Indeterminate')
+            qc_ma = result.qcfilter.get_masked_data(var_name, rm_assessments='Suspect')
             assert np.all(np.where(qc_ma.mask)[0] == np.arange(100, 170))
 
-            qc_ma = result.qcfilter.get_masked_data(var_name, rm_assessments='Bad')
+            qc_ma = result.qcfilter.get_masked_data(var_name, rm_assessments='Incorrect')
             index = np.concatenate([index_1, index_2, index_3])
             assert np.all(np.where(qc_ma.mask)[0] == index)
 
@@ -78,7 +78,7 @@ def test_qc_summary_multiple_assessment_names():
         var_name, index=index_6, test_meaning='Testing Incorrect', test_assessment='Incorrect'
     )
 
-    result = ds.qcfilter.create_qc_summary()
+    result = ds.qcfilter.create_qc_summary(normalize_assessment=False)
 
     assert result[qc_var_name].attrs['flag_assessments'] == [
         'Not failing',

--- a/tests/qc/test_qc_summary.py
+++ b/tests/qc/test_qc_summary.py
@@ -45,6 +45,17 @@ def test_qc_summary():
             index = np.concatenate([index_1, index_2, index_3])
             assert np.all(np.where(qc_ma.mask)[0] == index)
 
+            att_names = [
+                'fail_min',
+                'fail_max',
+                'fail_delta',
+                'valid_min',
+                'valid_max',
+                'valid_delta',
+            ]
+            for att_name in att_names:
+                assert att_name not in ds[f'qc_{var_name}'].attrs
+
         assert "Quality control summary implemented by ACT" in result.attrs['history']
 
         del ds
@@ -150,31 +161,13 @@ def test_qc_summary_big_data():
         'zrh',
         'osc',
     ]
-    skip_datastream_codes = [
-        'mmcrmom',
-        # 'microbasepi',
-        # 'lblch1a',
-        # '30co2flx4mmet',
-        # 'microbasepi2',
-        # '30co2flx60m',
-        # 'bbhrpavg1mlawer',
-        # 'co',
-        # 'lblch1b',
-        # '30co2flx25m',
-        # '30co2flx4m',
-        # 'armbeatm',
-        # 'armtrajcld',
-        # '1swfanalsiros1long',
-    ]
-    # skip_datastreams = ['nimmfrsraod5chcorM1.c1', 'anxaoso3M1.b0']
+    skip_datastream_codes = ['mmcrmom']
     num_files = 3
     expected_assessments = ['Not failing', 'Suspect', 'Indeterminate', 'Incorrect', 'Bad']
 
     testing_files = []
 
-    single_test = False
     if len(testing_files) == 0:
-        single_test = True
         filename = (
             f'test_qc_summary_big_data.{datetime.datetime.utcnow().strftime("%Y%m%d.%H%M%S")}.txt'
         )
@@ -191,9 +184,6 @@ def test_qc_summary_big_data():
             for datastream_dir in datastream_dirs:
                 if '-' in datastream_dir.name:
                     continue
-
-                # if datastream_dir.name in skip_datastreams:
-                #     continue
 
                 fn_obj = DatastreamParserARM(datastream_dir.name)
                 facility = fn_obj.facility
@@ -216,8 +206,7 @@ def test_qc_summary_big_data():
                 for ii in range(0, num_tests):
                     testing_files.append(random.choice(files))
 
-    if single_test:
-        print(f"Testing {len(testing_files)} files\n")
+        print(f"\nTesting {len(testing_files)} files\n")
         print(f"Output file name = {output_file}\n")
 
     for file in testing_files:

--- a/tests/qc/test_qc_summary.py
+++ b/tests/qc/test_qc_summary.py
@@ -36,14 +36,13 @@ def test_qc_summary():
             assert 'flag_masks' not in result[qc_var_name].attrs.keys()
             assert isinstance(result[qc_var_name].attrs['flag_values'], list)
 
-            assert np.sum(result[qc_var_name].values) == 610
+            assert np.sum(result[qc_var_name].values) == 880
 
             qc_ma = result.qcfilter.get_masked_data(var_name, rm_assessments='Suspect')
-            assert np.all(np.where(qc_ma.mask)[0] == np.arange(100, 170))
+            assert np.sum(np.where(qc_ma.mask)) == 9415
 
             qc_ma = result.qcfilter.get_masked_data(var_name, rm_assessments='Incorrect')
-            index = np.concatenate([index_1, index_2, index_3])
-            assert np.all(np.where(qc_ma.mask)[0] == index)
+            assert np.sum(np.where(qc_ma.mask)) == 89415
 
             att_names = [
                 'fail_min',
@@ -114,6 +113,118 @@ def test_qc_summary_multiple_assessment_names():
     assert np.sum(np.where(result[qc_var_name].values == 0)) == 884575
     qc_ma = result.qcfilter.get_masked_data(var_name, rm_assessments='Not failing')
     assert np.sum(np.where(qc_ma.mask)[0]) == 884575
+
+
+def test_qc_summary_unexpected_assessment_name():
+    var_name = 'temp_mean'
+    ds = read_arm_netcdf(EXAMPLE_MET1, keep_variables=var_name)
+
+    test_meanings = [
+        'Testing Bad',
+        'Testing Boomer',
+        'Testing Boomer Second',
+        'Testing Incorrect',
+        'Testing Indeterminate',
+        'Testing Sooner',
+        'Testing Suspect',
+    ]
+    test_assessments = [
+        'Bad',
+        'Boomer',
+        'boomer',
+        'Incorrect',
+        'Indeterminate',
+        'Sooner',
+        'Suspect',
+    ]
+
+    test_index_sums = [4950, 39900, 39900, 34950, 44950, 54950, 64950]
+
+    for ii, _ in enumerate(test_assessments):
+        ds.qcfilter.add_test(
+            var_name,
+            index=np.arange(ii * 100, ii * 100 + 100),
+            test_meaning=test_meanings[ii],
+            test_assessment=test_assessments[ii],
+        )
+
+    ds = ds.qcfilter.create_qc_summary(normalize_assessment=False)
+
+    qc_var_name = ds.qcfilter.check_for_ancillary_qc(var_name, add_if_missing=False)
+
+    # Make sure flag meanings are correct with new assessments.
+    assert sorted(ds[qc_var_name].attrs['flag_meanings']) == [
+        'Data Boomer',
+        'Data Sooner',
+        'Data incorrect use not recommended',
+        'Data incorrect use not recommended',
+        'Data suspect further analysis recommended',
+        'Data suspect further analysis recommended',
+        'Not failing quality control tests',
+    ]
+    assert sorted(ds[qc_var_name].attrs['flag_assessments']) == [
+        'Bad',
+        'Boomer',
+        'Incorrect',
+        'Indeterminate',
+        'Not failing',
+        'Sooner',
+        'Suspect',
+    ]
+    # Make sure the values and order of first 5 are as expected. The other non-standard
+    # assessments may be in different order with set operations.
+    assert ds[qc_var_name].attrs['flag_assessments'][:5] == [
+        'Not failing',
+        'Suspect',
+        'Indeterminate',
+        'Incorrect',
+        'Bad',
+    ]
+
+    for assessment, index_sum in zip(test_assessments, test_index_sums):
+        qc_ma = ds.qcfilter.get_masked_data(var_name, rm_assessments=assessment)
+        assert np.sum(np.where(qc_ma.mask)[0]) == index_sum
+
+    qc_ma = ds.qcfilter.get_masked_data(var_name, rm_assessments=['Bucky'])
+    assert np.sum(np.where(qc_ma.mask)[0]) == 0
+
+    qc_ma = ds.qcfilter.get_masked_data(var_name, rm_assessments=['Boomer', 'Sooner'])
+    assert np.sum(np.where(qc_ma.mask)[0]) == 94850
+
+    qc_ma = ds.qcfilter.get_masked_data(
+        var_name,
+        rm_assessments=['Boomer', 'Sooner', 'Indeterminate', 'Suspect', 'Bad', 'Incorrect'],
+    )
+    assert np.sum(np.where(qc_ma.mask)[0]) == 244650
+
+    del ds
+
+
+def test_qc_summary_scalar():
+    # Test scalar variables. Currently not implemented so just check that we
+    # don't do anything.
+    var_names = ['alt', 'temp_mean']
+    ds = read_arm_netcdf(EXAMPLE_MET1, keep_variables=var_names)
+
+    test_meanings = ['Testing Incorrect', 'Testing Suspect']
+    test_assessments = ['Incorrect', 'Suspect']
+
+    for var_name in var_names:
+        for ii, _ in enumerate(test_assessments):
+            ds.qcfilter.add_test(
+                var_name,
+                index=0,
+                test_meaning=test_meanings[ii],
+                test_assessment=test_assessments[ii],
+            )
+
+    with pytest.warns(UserWarning, match="Unable to process scalar variable"):
+        ds = ds.qcfilter.create_qc_summary(normalize_assessment=False)
+
+    assert 'flag_masks' in ds[f'qc_{var_names[0]}'].attrs.keys()
+    assert 'flag_values' not in ds[f'qc_{var_names[0]}'].attrs.keys()
+    assert 'flag_masks' not in ds[f'qc_{var_names[1]}'].attrs.keys()
+    assert 'flag_values' in ds[f'qc_{var_names[1]}'].attrs.keys()
 
 
 @pytest.mark.big

--- a/tests/qc/test_qcfilter.py
+++ b/tests/qc/test_qcfilter.py
@@ -45,10 +45,10 @@ def test_arm_qc():
     except ValueError:
         return
 
-    assert 'Suspect' not in ds[qc_variable].attrs['flag_assessments']
-    assert 'Incorrect' not in ds[qc_variable].attrs['flag_assessments']
-    assert 'Bad' in ds[qc_variable].attrs['flag_assessments']
-    assert 'Indeterminate' in ds[qc_variable].attrs['flag_assessments']
+    assert 'Suspect' in ds[qc_variable].attrs['flag_assessments']
+    assert 'Incorrect' in ds[qc_variable].attrs['flag_assessments']
+    assert 'Bad' not in ds[qc_variable].attrs['flag_assessments']
+    assert 'Indeterminate' not in ds[qc_variable].attrs['flag_assessments']
 
     # Check that defualt will update all variables in DQR
     for var_name in ['wdir_vec_mean', 'wdir_vec_std', 'wspd_arith_mean', 'wspd_vec_mean']:


### PR DESCRIPTION
These are some incremental updates to the method that creates a QC Summary. Also, working on improving the output netCDF file by improving how we correct the Dataset when writing to follow CF. Added some pytest.warn() to capture warnings and ensure they occur in our testing.

- [X ] Tests added
- [ X] Documentation reflects changes
- [ X] PEP8 Standards or use of linter
- [X ] Xarray Dataset or DataArray variable naming follows 'ds' or 'da' naming
