### PR TITLE
Adding radiation quality control tests

### DIFF
--- a/act/qc/bsrn_tests.py
+++ b/act/qc/bsrn_tests.py
@@ -821,7 +821,7 @@ class QCTests:
                 test_meaning=test_meaning,
             )
 
-    def k_test(
+    def normalized_rradiance_test(
         self,
         test,
         dni=None,
@@ -878,7 +878,7 @@ class QCTests:
             .. code-block:: python
 
                 ds = act.io.arm.read_arm_netcdf(act.tests.EXAMPLE_BRS, cleanup_qc=True)
-                ds.qcfilter.k_test(
+                ds.qcfilter.normalized_rradiance_test(
                     ['Clearness index', 'Upper total transmittance',
                      'Upper direct transmittance', 'Upper diffuse transmittance'],
                     dhi='down_short_diffuse_hemisp',
@@ -905,11 +905,11 @@ class QCTests:
         if test_options[0].lower() in test:
             if dni is None:
                 raise RuntimeError(
-                    "Need to set 'dni' keyword to perform 'Clearness index' test in k_test()."
+                    "Need to set 'dni' keyword to perform 'Clearness index' test in normalized_rradiance_test()."
                 )
             if dhi is None:
                 raise RuntimeError(
-                    "Need to set 'dhi' keyword to perform 'Clearness index' test in k_test()."
+                    "Need to set 'dhi' keyword to perform 'Clearness index' test in normalized_rradiance_test()."
                 )
 
             if use_dask and isinstance(self._ds[dni].data, da.Array):
@@ -943,11 +943,11 @@ class QCTests:
         if test_options[1].lower() in test:
             if dni is None:
                 raise RuntimeError(
-                    "Need to set 'dni' keyword to perform 'Upper total transmittance' test in k_test()."
+                    "Need to set 'dni' keyword to perform 'Upper total transmittance' test in normalized_rradiance_test()."
                 )
             if dhi is None:
                 raise RuntimeError(
-                    "Need to set 'dhi' keyword to perform 'Upper total transmittance' test in k_test()."
+                    "Need to set 'dhi' keyword to perform 'Upper total transmittance' test in normalized_rradiance_test()."
                 )
 
             if use_dask and isinstance(self._ds[dni].data, da.Array):
@@ -982,11 +982,11 @@ class QCTests:
         if test_options[2].lower() in test:
             if dni is None:
                 raise RuntimeError(
-                    "Need to set 'dni' keyword to perform 'Upper direct transmittance' test in k_test()."
+                    "Need to set 'dni' keyword to perform 'Upper direct transmittance' test in normalized_rradiance_test()."
                 )
             if ghi is None:
                 raise RuntimeError(
-                    "Need to set 'ghi' keyword to perform 'Upper direct transmittance' test in k_test()."
+                    "Need to set 'ghi' keyword to perform 'Upper direct transmittance' test in normalized_rradiance_test()."
                 )
 
             if use_dask and isinstance(self._ds[dni].data, da.Array):
@@ -1019,7 +1019,7 @@ class QCTests:
         if test_options[3].lower() in test:
             if dhi is None:
                 raise RuntimeError(
-                    "Need to set 'dhi' keyword to perform 'Upper diffuse transmittance' test in k_test()."
+                    "Need to set 'dhi' keyword to perform 'Upper diffuse transmittance' test in normalized_rradiance_test()."
                 )
 
             if use_dask and isinstance(self._ds[dhi].data, da.Array):

--- a/act/qc/bsrn_tests.py
+++ b/act/qc/bsrn_tests.py
@@ -831,8 +831,8 @@ class QCTests:
         lat_name='lat',
         lon_name='lon',
         alt_name='alt',
-        upper_total_transmittance_limit=1.4,
-        upper_diffuse_transmittance_limit=0.6,
+        upper_total_transmittance_limit=1.6,
+        upper_diffuse_transmittance_limit=1.0,
         use_dask=False,
     ):
         """
@@ -1026,12 +1026,12 @@ class QCTests:
                 sza = da.array(sza)
                 Sa = da.array(Sa)
                 K_diffuse = self._ds[dhi].values / (Sa * np.cos(np.radians(sza)))
-                index = (sza > 0) & (sza < 90) & (K_diffuse > 0)
+                index = (sza > 0) & (sza < 90) & (K_diffuse > upper_diffuse_transmittance_limit)
                 index = index.compute()
 
             else:
                 K_diffuse = self._ds[dhi].values / (Sa * np.cos(np.radians(sza)))
-                index = (sza > 0) & (sza < 90) & (K_diffuse > 0)
+                index = (sza > 0) & (sza < 90) & (K_diffuse > upper_diffuse_transmittance_limit)
 
             test_meaning = f"Diffuse transmittance greater than {upper_diffuse_transmittance_limit}"
             self._ds.qcfilter.add_test(

--- a/examples/qc/plot_qc_bsrn.py
+++ b/examples/qc/plot_qc_bsrn.py
@@ -65,7 +65,7 @@ ds.qcfilter.bsrn_comparison_tests(
 )
 
 # Add K-tests QC to ancillary QC variables.
-ds.qcfilter.k_test(
+ds.qcfilter.normalized_rradiance_test(
     [
         'Clearness index',
         'Upper total transmittance',

--- a/examples/qc/plot_qc_bsrn.py
+++ b/examples/qc/plot_qc_bsrn.py
@@ -64,6 +64,19 @@ ds.qcfilter.bsrn_comparison_tests(
     direct_normal_SW_dn_name='short_direct_normal',
 )
 
+# Add K-tests QC to ancillary QC variables.
+ds.qcfilter.k_test(
+    [
+        'Clearness index',
+        'Upper total transmittance',
+        'Upper direct transmittance',
+        'Upper diffuse transmittance',
+    ],
+    dni='short_direct_normal',
+    dhi='down_short_hemisp',
+    ghi='down_short_diffuse_hemisp',
+)
+
 # Creat Plot Display and plot data including embedded QC from data file
 variable = 'down_short_hemisp'
 display = act.plotting.TimeSeriesDisplay(ds, figsize=(15, 10), subplot_shape=(2,))

--- a/tests/qc/test_bsrn_tests.py
+++ b/tests/qc/test_bsrn_tests.py
@@ -232,6 +232,11 @@ def test_bsrn_limits_test():
         )
         ds['up_long_hemisp'].values[0:100] = ds['up_long_hemisp'].values[0:100] - 200
 
+        # Closure test modified data
+        ds['down_short_diffuse_hemisp'].values[714:814] = (
+            ds['down_short_diffuse_hemisp'].values[714:814] + 50.0
+        )
+
         ds.qcfilter.bsrn_comparison_tests(
             [
                 'Global over Sum SW Ratio',
@@ -240,6 +245,7 @@ def test_bsrn_limits_test():
                 'LW down to air temp',
                 'LW up to air temp',
                 'LW down to LW up',
+                'Closure',
             ],
             gbl_SW_dn_name='down_short_hemisp',
             glb_diffuse_SW_dn_name='down_short_diffuse_hemisp',
@@ -256,11 +262,11 @@ def test_bsrn_limits_test():
 
         # Ratio of Global over Sum SW
         result = ds.qcfilter.get_qc_test_mask('down_short_hemisp', test_number=5)
-        assert np.sum(result) == 190
+        assert np.sum(result) == 276
 
         # Diffuse Ratio
         result = ds.qcfilter.get_qc_test_mask('down_short_hemisp', test_number=6)
-        assert np.sum(result) == 47
+        assert np.sum(result) == 103
 
         # Shortwave up comparison
         result = ds.qcfilter.get_qc_test_mask('up_short_hemisp', test_number=5)
@@ -274,6 +280,26 @@ def test_bsrn_limits_test():
         result = ds.qcfilter.get_qc_test_mask('down_long_hemisp_shaded', test_number=5)
         assert np.sum(result) == 976
 
-        # Lonwave down to longwave up comparison
+        # Longwave down to longwave up comparison
         result = ds.qcfilter.get_qc_test_mask('down_long_hemisp_shaded', test_number=6)
         assert np.sum(result) == 100
+
+        # Closure test
+        assert (
+            ds['qc_down_short_hemisp'].attrs['flag_meanings'][6]
+            == 'Closure test indicating value outside of expected range'
+        )
+        result = ds.qcfilter.get_qc_test_mask('down_short_hemisp', test_number=7)
+        assert np.sum(result) == 38
+        assert (
+            ds['qc_short_direct_normal'].attrs['flag_meanings'][6]
+            == 'Closure test indicating value outside of expected range'
+        )
+        result = ds.qcfilter.get_qc_test_mask('short_direct_normal', test_number=7)
+        assert np.sum(result) == 38
+        assert (
+            ds['qc_down_short_diffuse_hemisp'].attrs['flag_meanings'][7]
+            == 'Closure test indicating value outside of expected range'
+        )
+        result = ds.qcfilter.get_qc_test_mask('down_short_diffuse_hemisp', test_number=8)
+        assert np.sum(result) == 38

--- a/tests/qc/test_bsrn_tests.py
+++ b/tests/qc/test_bsrn_tests.py
@@ -336,6 +336,8 @@ def test_k_test():
             dhi='down_short_diffuse_hemisp',
             ghi='down_short_hemisp',
             use_dask=use_dask,
+            upper_total_transmittance_limit=1.4,
+            upper_diffuse_transmittance_limit=0.6,
         )
 
         test_number = (
@@ -361,7 +363,7 @@ def test_k_test():
             + 1
         )
         result = ds.qcfilter.get_qc_test_mask('down_short_diffuse_hemisp', test_number=test_number)
-        assert np.sum(np.where(result)) == 812004
+        assert np.sum(np.where(result)) == 2367
 
         test_number = (
             ds['qc_short_direct_normal']

--- a/tests/qc/test_bsrn_tests.py
+++ b/tests/qc/test_bsrn_tests.py
@@ -305,7 +305,7 @@ def test_bsrn_limits_test():
         assert np.sum(result) == 38
 
 
-def test_k_test():
+def test_normalized_rradiance_test():
     keep_vars = [
         'short_direct_normal',
         'down_short_diffuse_hemisp',
@@ -323,14 +323,14 @@ def test_k_test():
     ]
     for test in tests:
         with pytest.raises(RuntimeError):
-            ds.qcfilter.k_test(test)
+            ds.qcfilter.normalized_rradiance_test(test)
 
     for use_dask in [False, True]:
         ds = read_arm_netcdf(EXAMPLE_BRS, keep_variables=keep_vars)
         data = ds['short_direct_normal'].values
         data[1050:1100] = data[1050:1100] + 400
         ds['short_direct_normal'].values = data
-        ds.qcfilter.k_test(
+        ds.qcfilter.normalized_rradiance_test(
             tests,
             dni='short_direct_normal',
             dhi='down_short_diffuse_hemisp',

--- a/tests/retrievals/test_radiation.py
+++ b/tests/retrievals/test_radiation.py
@@ -7,9 +7,65 @@ import act
 def test_calculate_sirs_variable():
     sirs_ds = act.io.arm.read_arm_netcdf(act.tests.sample_files.EXAMPLE_SIRS)
     met_ds = act.io.arm.read_arm_netcdf(act.tests.sample_files.EXAMPLE_MET1)
+    mfrsr_ds = act.io.arm.read_arm_netcdf(act.tests.sample_files.EXAMPLE_MFRSR)
 
+    elevation, _, _ = act.utils.geo_utils.get_solar_azimuth_elevation(
+        sirs_ds['lat'].values, sirs_ds['lon'].values, sirs_ds['time'].values
+    )
+    sirs_ds['solar_zenith_angle'] = xr.DataArray(
+        90.0 - elevation,
+        dims=['time'],
+        attrs={
+            'long_name': 'Solar zenith angle',
+            'units': 'degrees',
+        },
+    )
+
+    # old
     ds = act.retrievals.radiation.calculate_dsh_from_dsdh_sdn(sirs_ds)
     assert np.isclose(np.nansum(ds['derived_down_short_hemisp'].values), 61157.71, atol=0.1)
+
+    # new
+    ds = act.retrievals.radiation.calculate_ghi_from_dni_dhi(sirs_ds)
+    assert np.isclose(np.nansum(ds['derived_down_short_hemisp'].values), 61157.71, atol=0.1)
+
+    # Test with providing solar_zenith variable in Dataset
+    ds = act.retrievals.radiation.calculate_ghi_from_dni_dhi(
+        sirs_ds, solar_zenith='solar_zenith_angle'
+    )
+    assert np.isclose(np.nansum(ds['derived_down_short_hemisp'].values), 61157.71, atol=0.1)
+
+    ds = act.retrievals.radiation.calculate_dhi_from_dni_ghi(sirs_ds)
+    assert np.isclose(np.nansum(ds['derived_down_short_diffuse_hemisp'].values), 59825.39, atol=0.1)
+
+    # Test with providing solar_zenith variable in Dataset
+    ds = act.retrievals.radiation.calculate_dhi_from_dni_ghi(
+        sirs_ds, solar_zenith='solar_zenith_angle'
+    )
+    assert np.isclose(np.nansum(ds['derived_down_short_diffuse_hemisp'].values), 59825.39, atol=0.1)
+
+    # Test direct normal
+    mfrsr_ds = act.retrievals.radiation.calculate_dni_from_dhi_ghi(
+        mfrsr_ds,
+        ghi='hemisp_narrowband_filter3',
+        dhi='diffuse_hemisp_narrowband_filter3',
+        derived='derived_direct_normal_narrowband_filter3',
+    )
+    assert np.isclose(
+        np.nansum(mfrsr_ds['derived_direct_normal_narrowband_filter3'].values), 2553.92, atol=0.1
+    )
+
+    # Test with providing solar_zenith variable in Dataset
+    mfrsr_ds = act.retrievals.radiation.calculate_dni_from_dhi_ghi(
+        mfrsr_ds,
+        ghi='hemisp_narrowband_filter3',
+        dhi='diffuse_hemisp_narrowband_filter3',
+        derived='derived_direct_normal_narrowband_filter3',
+        solar_zenith='solar_zenith_angle',
+    )
+    assert np.isclose(
+        np.nansum(mfrsr_ds['derived_direct_normal_narrowband_filter3'].values), 2553.59, atol=0.1
+    )
 
     ds = act.retrievals.radiation.calculate_irradiance_stats(
         ds,


### PR DESCRIPTION
This PR adds additional quality control tests for radiation data. Uses the Best Practices Handbook for the Collection and Use of Solar Resource Data for Solar Energy Applications: Fourth Edition. 

- [ X] Tests added
- [ X] Documentation reflects changes
- [X ] PEP8 Standards or use of linter
- [ X] Xarray Dataset or DataArray variable naming follows 'ds' or 'da' naming
