### PR TITLE
ENH: Fixing airnow tests

### DIFF
--- a/tests/discovery/test_airnow.py
+++ b/tests/discovery/test_airnow.py
@@ -23,8 +23,8 @@ def test_get_airnow():
         assert results['ReportingArea'][3] == 'Aurora and Elgin'
 
         results = act.discovery.get_airnow_obs(token, date='2022-05-01', zipcode=60108, distance=50)
-        assert results['AQI'].values[0] == 26
-        assert results['ParameterName'].values[1] == 'PM2.5'
+        assert results['AQI'].values[0] == 13
+        assert results['ParameterName'].values[0] == 'PM2.5'
         assert results['CategoryName'].values[0] == 'Good'
 
         results = act.discovery.get_airnow_obs(token, zipcode=60108, distance=50)
@@ -40,8 +40,8 @@ def test_get_airnow():
         results = act.discovery.get_airnow_obs(
             token, date='2022-05-01', distance=50, latlon=[41.958, -88.12]
         )
-        assert results['AQI'].values[0] == 26
-        assert results['ParameterName'].values[1] == 'PM2.5'
+        assert results['AQI'].values[0] == 13
+        assert results['ParameterName'].values[0] == 'PM2.5'
         assert results['CategoryName'].values[0] == 'Good'
 
         lat_lon = '-88.245401,41.871346,-87.685099,42.234359'


### PR DESCRIPTION
Looks like the airnow tests are failing
<!-- Please remove check-list items that aren't relevant to your changes -->

- [ ] Documentation reflects changes
- [ ] PEP8 Standards or use of linter
- [ ] Xarray Dataset or DataArray variable naming follows 'ds' or 'da' naming
