### PR TITLE
FIX: `read_arm_mmcr` fails when using a read-only input file

### DIFF
--- a/act/io/arm.py
+++ b/act/io/arm.py
@@ -841,12 +841,12 @@ def read_arm_mmcr(filenames):
     # read it in with xarray
     multi_ds = []
     for f in filenames:
-        nc = Dataset(f, 'r')
+        nc = Dataset(f, 'a', diskless=True)
+        # Change heights name to range to read appropriately to xarray
+        if 'heights' in nc.dimensions:
+            nc.renameDimension('heights', 'range')
         if nc is not None:
             ds = xr.open_dataset(xr.backends.NetCDF4DataStore(nc))
-            # Change heights name to range to read appropriately to xarray
-            if 'heights' in ds.dims:
-                ds = ds.rename_dims({"heights": "range"})
             multi_ds.append(ds)
     # Concatenate datasets together
     if len(multi_ds) > 1:

--- a/act/io/arm.py
+++ b/act/io/arm.py
@@ -841,12 +841,11 @@ def read_arm_mmcr(filenames):
     # read it in with xarray
     multi_ds = []
     for f in filenames:
-        nc = Dataset(f, 'a')
-        # Change heights name to range to read appropriately to xarray
-        if 'heights' in nc.dimensions:
-            nc.renameDimension('heights', 'range')
+        nc = Dataset(f, 'r')
         if nc is not None:
             ds = xr.open_dataset(xr.backends.NetCDF4DataStore(nc))
+            # Change heights name to range to read appropriately to xarray
+            ds = ds.rename_dims({"heights": "range"})
             multi_ds.append(ds)
     # Concatenate datasets together
     if len(multi_ds) > 1:

--- a/act/io/arm.py
+++ b/act/io/arm.py
@@ -845,7 +845,8 @@ def read_arm_mmcr(filenames):
         if nc is not None:
             ds = xr.open_dataset(xr.backends.NetCDF4DataStore(nc))
             # Change heights name to range to read appropriately to xarray
-            ds = ds.rename_dims({"heights": "range"})
+            if 'heights' in ds.dims:
+                ds = ds.rename_dims({"heights": "range"})
             multi_ds.append(ds)
     # Concatenate datasets together
     if len(multi_ds) > 1:


### PR DESCRIPTION
- [x ] Closes #887 
- [X ] PEP8 Standards or use of linter
- [X] Xarray Dataset or DataArray variable naming follows 'ds' or 'da' naming
