### PR TITLE
CI: Remove Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         os: [macOS, ubuntu, Windows]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Removing Python 3.9 as we want to check the 3 most recent versions.