### PR TITLE
Scikit posthocs

### DIFF
--- a/tests/qc/test_qcfilter.py
+++ b/tests/qc/test_qcfilter.py
@@ -300,6 +300,8 @@ def test_qcfilter():
 
 @pytest.mark.skipif(not SCIKIT_POSTHOCS_AVAILABLE, reason='scikit_posthocs is not installed.')
 def test_qcfilter2():
+    import scikit_posthocs
+
     ds = read_arm_netcdf(EXAMPLE_IRT25m20s)
     var_name = 'inst_up_long_dome_resist'
     expected_qc_var_name = 'qc_' + var_name
@@ -325,14 +327,22 @@ def test_qcfilter2():
     )
 
     ds.qcfilter.add_gesd_test(var_name, test_assessment='Bad')
-    assert np.sum(ds[expected_qc_var_name].values) == 204
+    if scikit_posthocs.__version__ >= '0.11.3':
+        value = 188
+    else:
+        value = 204
+    assert np.sum(ds[expected_qc_var_name].values) == value
     assert ds[expected_qc_var_name].attrs['flag_masks'] == [1, 4, 8]
     assert ds[expected_qc_var_name].attrs['flag_meanings'][-1] == (
         'Value failed generalized Extreme Studentized Deviate test with an alpha of 0.05'
     )
 
     ds.qcfilter.add_gesd_test(var_name, alpha=0.1)
-    assert np.sum(ds[expected_qc_var_name].values) == 332
+    if scikit_posthocs.__version__ >= '0.11.3':
+        value = 284
+    else:
+        value = 332
+    assert np.sum(ds[expected_qc_var_name].values) == value
     assert ds[expected_qc_var_name].attrs['flag_masks'] == [1, 4, 8, 16]
     assert ds[expected_qc_var_name].attrs['flag_meanings'][-1] == (
         'Value failed generalized Extreme Studentized Deviate test with an alpha of 0.1'

--- a/tests/qc/test_qcfilter.py
+++ b/tests/qc/test_qcfilter.py
@@ -300,8 +300,6 @@ def test_qcfilter():
 
 @pytest.mark.skipif(not SCIKIT_POSTHOCS_AVAILABLE, reason='scikit_posthocs is not installed.')
 def test_qcfilter2():
-    import scikit_posthocs
-
     ds = read_arm_netcdf(EXAMPLE_IRT25m20s)
     var_name = 'inst_up_long_dome_resist'
     expected_qc_var_name = 'qc_' + var_name

--- a/tests/retrievals/test_sonde.py
+++ b/tests/retrievals/test_sonde.py
@@ -130,5 +130,5 @@ def test_calculate_heffter_pbl():
     assert ds['pblht_heffter'].values == 960.0
     np.testing.assert_almost_equal(ds['atm_pres_ss'].values[1], 994.9, 1)
     np.testing.assert_almost_equal(ds['potential_temperature_ss'].values[4], 298.4, 1)
-    assert np.sum(ds['bottom_inversion'].values) == 7426
-    assert np.sum(ds['top_inversion'].values) == 7903
+    assert np.sum(ds['bottom_inversion'].values) == 7426.0
+    assert np.sum(ds['top_inversion'].values) == 7845.0  # previous value 7903

--- a/tests/retrievals/test_sonde.py
+++ b/tests/retrievals/test_sonde.py
@@ -131,4 +131,4 @@ def test_calculate_heffter_pbl():
     np.testing.assert_almost_equal(ds['atm_pres_ss'].values[1], 994.9, 1)
     np.testing.assert_almost_equal(ds['potential_temperature_ss'].values[4], 298.4, 1)
     assert np.sum(ds['bottom_inversion'].values) == 7426.0
-    assert np.sum(ds['top_inversion'].values) == 7845.0  # previous value 7903
+    assert np.sum(ds['top_inversion'].values) == 7903.0


### PR DESCRIPTION
The underlying library had a change to fix an issue. This changed the result of the test. Updated expected values for the test.

- [X ] Closes #910
- [ X] PEP8 Standards or use of linter
