### PR TITLE
FIX: Update violin plot to use new parameter orientation.

### DIFF
--- a/act/plotting/distributiondisplay.py
+++ b/act/plotting/distributiondisplay.py
@@ -777,8 +777,9 @@ class DistributionDisplay(Display):
         dsname : str or None
             The name of the datastream the field is contained in. Set
             to None to let ACT automatically determine this.
-        vert : Boolean, Default: True
-            Display violin plot vertical. False will display horizontal.
+        orientation : str
+            Orientation of the violin plot. Options are 'vertical' and 'horizontal'.
+            Default is vertical.
         showmeans : Boolean; Default: False
             If True, will display the mean of the datastream.
         showmedians : Boolean; Default: False
@@ -829,7 +830,7 @@ class DistributionDisplay(Display):
         scc = self.axes[subplot_index].violinplot(
             ndata,
             positions=positions,
-            vert=vert,
+            orientation='vertical',
             showmeans=showmeans,
             showmedians=showmedians,
             showextrema=showextrema,

--- a/act/plotting/distributiondisplay.py
+++ b/act/plotting/distributiondisplay.py
@@ -756,7 +756,7 @@ class DistributionDisplay(Display):
         field,
         positions=None,
         dsname=None,
-        vert=True,
+        orientation='vertical',
         showmeans=True,
         showmedians=True,
         showextrema=True,
@@ -830,7 +830,7 @@ class DistributionDisplay(Display):
         scc = self.axes[subplot_index].violinplot(
             ndata,
             positions=positions,
-            orientation='vertical',
+            orientation=orientation,
             showmeans=showmeans,
             showmedians=showmedians,
             showextrema=showextrema,
@@ -854,7 +854,7 @@ class DistributionDisplay(Display):
 
         # Define the axe title, x-axis label, y-axis label
         self.axes[subplot_index].set_title(set_title)
-        if vert is True:
+        if orientation == 'vertical':
             self.axes[subplot_index].set_ylabel(axtitle)
             if positions is None:
                 self.axes[subplot_index].set_xticks([])

--- a/tests/plotting/test_distributiondisplay.py
+++ b/tests/plotting/test_distributiondisplay.py
@@ -361,7 +361,7 @@ def test_violin2():
     display = DistributionDisplay(ds)
 
     # Create violin display of mean temperature
-    display.plot_violin('temp_mean', vert=False)
+    display.plot_violin('temp_mean', orientation='horizontal')
 
     ds.close()
 


### PR DESCRIPTION
vert is deprecated, need to use orientation now.

<!-- Please remove check-list items that aren't relevant to your changes -->

- [x] Tests updated
- [x] Documentation reflects changes
- [x] PEP8 Standards or use of linter