### PR TITLE
FIX: Update extract function to new standards.

### DIFF
--- a/act/utils/io_utils.py
+++ b/act/utils/io_utils.py
@@ -132,7 +132,7 @@ def unpack_tar(
     for tar_file in tar_files:
         try:
             tar = tarfile.open(tar_file)
-            tar.extractall(path=out_dir)
+            tar.extractall(path=out_dir, filter='data')
             result = [str(Path(out_dir, ii.name)) for ii in tar.getmembers()]
             files.extend(result)
             tar.close()


### PR DESCRIPTION
Updating the tar function so that it follows the changes stated for python 3.14. See docs here:

https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extractall

@AdamTheisen @mgrover1 If you both could review and see if this is fine. 'data' according to the docs looks to be the safest.