### PR TITLE
Setting decode_timedelta keyword in Xarray.open_dataset()

### DIFF
--- a/act/io/arm.py
+++ b/act/io/arm.py
@@ -128,6 +128,12 @@ def read_arm_netcdf(
     if len(filenames) > 1 and not isinstance(filenames, str):
         kwargs['combine_attrs'] = combine_attrs
 
+    # An update to xarray.open_dataset is changing from allowing decode_timedelta to be set to None
+    # (the current default) and if so set to match decode_times. This code is to set the keyword to
+    # make the warning go away.
+    if 'decode_timedelta' not in kwargs.keys():
+        kwargs['decode_timedelta'] = kwargs['decode_times']
+
     # Check if keep_variables is set. If so determine correct drop_variables
     if keep_variables is not None:
         drop_variables = None

--- a/act/utils/data_utils.py
+++ b/act/utils/data_utils.py
@@ -115,7 +115,7 @@ class ChangeUnits:
                 TypeError,
                 pint.errors.DimensionalityError,
                 pint.errors.UndefinedUnitError,
-                np._core._exceptions.UFuncTypeError,
+                np.core._exceptions.UFuncTypeError,
             ):
                 if raise_error:
                     raise ValueError(


### PR DESCRIPTION
Xarray.open_dataset() is changing the default to keyword decode_timedelta to no longer default to None. This is raising a warning. This update checks the other keyword decode_times and sets decode_timedelta to the same value to keep the same functionality into the future.

- [X ] Closes #909 
- [X ] Documentation reflects changes
- [ X] PEP8 Standards or use of linter
- [ X] Xarray Dataset or DataArray variable naming follows 'ds' or 'da' naming
