### PR TITLE
ENH: Fix for multiple QC variables in ancillary QC

### DIFF
--- a/act/plotting/timeseriesdisplay.py
+++ b/act/plotting/timeseriesdisplay.py
@@ -1525,6 +1525,7 @@ class TimeSeriesDisplay(Display):
         edgecolor='face',
         set_shading='auto',
         cvd_friendly=False,
+        ylabel=None,
         **kwargs,
     ):
         """
@@ -1556,6 +1557,9 @@ class TimeSeriesDisplay(Display):
         cvd_friendly : boolean
             Set to true if you want to use the integrated color vision deficiency (CVD) friendly
             colors for green/red based on the Homeyer colormap
+        ylabel : str
+            Label for the y-axis of the plot.  This will take the place of the
+            default which is to get the variable name or units.
         **kwargs : keyword arguments
             The keyword arguments for :func:`plt.broken_barh`.
 
@@ -1723,6 +1727,9 @@ class TimeSeriesDisplay(Display):
             dim_name = list(set(self._ds[dsname][qc_data_field].dims) - {'time'})
             try:
                 ytitle = f"{dim_name[0]} ({self._ds[dsname][dim_name[0]].attrs['units']})"
+                # Set ylabel after previous default titles if ylabel is set
+                if ylabel is not None:
+                    ytitle = ylabel
                 ax.set_ylabel(ytitle)
             except KeyError:
                 pass

--- a/act/qc/qcfilter.py
+++ b/act/qc/qcfilter.py
@@ -77,13 +77,14 @@ class QCFilter(qctests.QCTests, comparison_tests.QCTests, bsrn_tests.QCTests, qc
         qc_var_name = None
         try:
             ancillary_variables = self._ds[var_name].attrs['ancillary_variables']
+            var_dims = self._ds[var_name].dims
             if isinstance(ancillary_variables, str):
                 ancillary_variables = ancillary_variables.split()
-
             for var in ancillary_variables:
                 for attr, value in self._ds[var].attrs.items():
                     if attr == 'standard_name' and 'quality_flag' in value:
-                        qc_var_name = var
+                        if var_dims == self._ds[var].dims:
+                            qc_var_name = var
 
             if add_if_missing and qc_var_name is None:
                 qc_var_name = self._ds.qcfilter.create_qc_variable(var_name, flag_type=flag_type)


### PR DESCRIPTION
<!-- Please remove check-list items that aren't relevant to your changes -->

- [x] Documentation reflects changes
- [x] PEP8 Standards or use of linter
- [x] Xarray Dataset or DataArray variable naming follows 'ds' or 'da' naming
