### PR TITLE
ADD: PBL Height Retrieval via Gradient Methods

### DIFF
--- a/act/retrievals/__init__.py
+++ b/act/retrievals/__init__.py
@@ -7,12 +7,16 @@ import lazy_loader as lazy
 
 __getattr__, __dir__, __all__ = lazy.attach(
     __name__,
-    submodules=['aeri', 'cbh', 'doppler_lidar', 'irt', 'radiation', 'sonde', 'sp2'],
+    submodules=['aeri', 'cbh', 'doppler_lidar', 'irt', 'pbl_lidar', 'radiation', 'sonde', 'sp2'],
     submod_attrs={
         'aeri': ['aeri2irt'],
         'cbh': ['generic_sobel_cbh'],
         'doppler_lidar': ['compute_winds_from_ppi'],
         'irt': ['sst_from_irt', 'sum_function_irt'],
+        'pbl_lidar': [
+            'calculate_gradient_pbl',
+            'calculate_modified_gradient_pbl',
+        ],
         'radiation': [
             'calculate_dsh_from_dsdh_sdn',
             'calculate_irradiance_stats',

--- a/act/retrievals/pbl_lidar.py
+++ b/act/retrievals/pbl_lidar.py
@@ -15,6 +15,13 @@ def calculate_gradient_pbl(ds, parm="beta_att", dis_parm="range", min_height=100
     through a gradient method, where the PBL height is identified through the
     sharpest negative gradient.
 
+    Note:
+    This retrieval method should be applied under a cloud-free, well-mixed PBL condition.
+
+    It is not expected perform well in cloud capped boundary layers.
+    Additional PRs will be included within the near future to address more PBL
+    environmental conditions.
+
     Parameters
     ----------
     ds : xarray.Dataset
@@ -94,6 +101,16 @@ def calculate_modified_gradient_pbl(
     Estimation of the Planetary Boundary Layer (PBL) height from a backscatter LIDAR
     through a modified gradient method, where the first significant inflection point
     within the profile is identified rather than the traditional sharpest negative gradient.
+
+    Also conforms to the depolarization ratio threshold PBL height estimate when
+    the `parm` input is properly selected.
+
+    Note:
+    This retrieval method should be applied under a cloud-free, well-mixed PBL condition.
+
+    It is not expected perform well in cloud capped boundary layers.
+    Additional PRs will be included within the near future to address more PBL
+    environmental conditions.
 
     Parameters
     ----------

--- a/act/retrievals/pbl_lidar.py
+++ b/act/retrievals/pbl_lidar.py
@@ -1,0 +1,171 @@
+"""
+Functions for planetary boundary layer height estimation
+related calculations from lidar
+
+"""
+import xarray as xr
+import numpy as np
+
+from scipy.signal import find_peaks
+
+
+def calculate_gradient_pbl(ds, parm="beta_att", dis_parm="range", min_height=100, smooth_dis=5):
+    """
+    Estimation of the Planetary Boundary Layer (PBL) height from a backscatter LIDAR
+    through a gradient method, where the PBL height is identified through the
+    sharpest negative gradient.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Dataset containing the zenith-pointing remote sensing data.
+    parm : str
+        Variable in the dataset to compute gradient on (e.g., attenuated backscatter).
+    dis_parm : str
+        Distance-from-instrument coordinate (e.g., 'range' or 'height').
+    min_height : float
+        Minimum allowed PBL height in meters.
+    smooth_dis : int
+        Number of bins to average vertical profile over to smooth data
+
+    Returns
+    -------
+    ds : xarray.Dataset
+        Dataset with a new variable `pbl_gradient` containing PBL heights.
+
+    References
+    ----------
+    Hayden, K. L. et al. (1997): The vertical chemical and meteorological
+        structure of the boundary layer in the Lower Fraser Valley during
+        Pacific ’93. Atmospheric Environment, 31, 2089–2105,
+        https://doi.org/10.1016/S1352-2310(96)00300-7.
+
+    Li, H., Yang, Y., Hu, X.M., Huang, Z., Wang, G., Zhang, B., Zhang, T. (2017).
+        Evaluation of retrieval methods of daytime convective boundary layer
+        height based on lidar data. J. Geophys. Res. 122, 4578–4593.
+        https://doi.org/10.1002/2016JD025620
+
+    Wang, Y.-C., Wang, S.-H., Lewis, J. R., Chang, S.-C., & Griffith, S. M.
+        (2021). Determining Planetary Boundary Layer Height by Micro-pulse Lidar
+        with Validation by UAV Measurements. Aerosol and Air Quality Research,
+        21 (5), 200336. Retrieved 2025-10-15, from
+        https://aaqr.org/articles/aaqr-20-06-oa-0336
+    """
+    # smooth the data within the range bins (~20m bins)
+    smoothed = ds[parm].rolling({dis_parm: smooth_dis}, center=True).mean()
+
+    # Loop over time to find the sharpest negative gradient
+    pbl_heights = []
+
+    for t in range(len(ds["time"].values)):
+        profile = smoothed.isel(time=t).values  # 1D backscatter profile
+        height = smoothed[dis_parm].values  # 1D height coordinate
+
+        # Compute first derivative
+        p_grad = np.gradient(profile, height)
+
+        # Find the first negative gradient
+        indice = next(i for i, x in enumerate(p_grad) if x < 0)
+
+        # Choose the first peak above a certain altitude (e.g., ignore surface noise)
+        if height[indice] > min_height:
+            pbl_heights.append(height[indice])
+        else:
+            pbl_heights.append(np.nan)
+
+    # Add result to dataset
+    ds = ds.assign(pbl_gradient=xr.DataArray(pbl_heights, dims="time"))
+    ds['pbl_gradient'].attrs[
+        "description"
+    ] = "Planetary Boundary Layer Estimate via Gradient Method"
+    ds['pbl_gradient'].attrs["input_parameter"] = parm
+    if hasattr(ds[dis_parm], "units"):
+        ds['pbl_gradient'].attrs["units"] = ds[dis_parm].attrs["units"]
+    else:
+        ds['pbl_gradient'].attrs["units"] = "meters"
+
+    return ds
+
+
+def calculate_modified_gradient_pbl(
+    ds, parm="beta_att", dis_parm="range", min_height=100, threshold=1e-3, smooth_dis=5
+):
+    """
+    Estimation of the Planetary Boundary Layer (PBL) height from a backscatter LIDAR
+    through a modified gradient method, where the first significant inflection point
+    within the profile is identified rather than the traditional sharpest negative gradient.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Dataset containing the zenith-pointing remote sensing data.
+    parm : str
+        Variable in the dataset to compute gradient on (e.g., attenuated backscatter).
+    dis_parm : str
+        Distance-from-instrument coordinate (e.g., 'range' or 'height').
+    min_height : float
+        Minimum allowed PBL height in meters.
+    threshold : float
+        Prominence value to use within scipy.signal.find_peaks
+    smooth_dis : int
+        Number of bins to average vertical profile over to smooth data
+
+    Returns
+    -------
+    ds : xarray.Dataset
+        Dataset with a new variable `pbl_mod_gradient` containing PBL heights.
+
+    References
+    ----------
+    Satheesh, A. R., Warner, G., Cai, J., Juliano, T., O'Brien, J. R.,
+        & Wagner, T. (2025). Boundary Layer in Multiple Places (BLIMP)
+        (v2025.05.29). Zenodo. https://doi.org/10.5281/zenodo.15545989
+
+    Jackson, R., O’Brien, J., Wang, J., Fytanidis, D., Muradyan, P.,
+        Grover, M., Raut, B., Collis, S., Tuftedal, M., Anderson, G.,
+        agner, T. J., Nesbitt, S., Tan. H., Wefer, D., & Hammond, M. (2025).
+        The thermodynamic and kinematic structure of the planetary boundary
+        layer for a summer lake breeze day in Chicago. Journal of Geophysical
+        Research: Atmospheres, in preparation.
+    """
+    # smooth the data within the range bins (~20m bins)
+    smoothed = ds[parm].rolling({dis_parm: smooth_dis}, center=True).mean()
+
+    # Loop over time to get peaks in second derivative
+    pbl_heights = []
+
+    for t in range(len(ds["time"].values)):
+        profile = smoothed.isel(time=t).values  # 1D backscatter profile
+        height = smoothed[dis_parm].values  # 1D height coordinate
+
+        # Compute first and second derivatives
+        d1 = np.gradient(profile, height)
+        d2 = np.gradient(d1, height)
+
+        # Invert second derivative to find local minima
+        # These can indicate PBL top or inversion-like transitions
+        peaks, _ = find_peaks(-d2, distance=10, prominence=threshold)
+
+        if len(peaks) > 0:
+            # Choose the first peak above a certain altitude (e.g., ignore surface noise)
+            valid_peaks = [p for p in peaks if height[p] > min_height]
+            if valid_peaks:
+                pbl_heights.append(height[valid_peaks[0]])
+            else:
+                pbl_heights.append(np.nan)
+        else:
+            pbl_heights.append(np.nan)
+
+    # Add result to dataset
+    ds = ds.assign(pbl_mod_gradient=xr.DataArray(pbl_heights, dims="time"))
+    ds['pbl_mod_gradient'].attrs[
+        "description"
+    ] = "Planetary Boundary Layer Estimate via modified gradient method"
+    ds['pbl_mod_gradient'].attrs["input_parameter"] = parm
+    ds['pbl_mod_gradient'].attrs["prominence_threshold"] = threshold
+    if hasattr(ds[dis_parm], "units"):
+        ds['pbl_mod_gradient'].attrs["units"] = ds[dis_parm].attrs["units"]
+    else:
+        ds['pbl_mod_gradient'].attrs["units"] = "meters"
+
+    return ds

--- a/examples/retrievals/plot_gradient_pbl.py
+++ b/examples/retrievals/plot_gradient_pbl.py
@@ -1,0 +1,69 @@
+"""
+Planetary Boundary Layer Height Gradient Method Retrievals
+----------------------------------------------------------
+
+This example shows how to estimate the planetary boundary layer
+height via a gradient method retrieval
+
+Author: Joe O'Brien
+"""
+
+
+import act
+from arm_test_data import DATASETS
+
+# Read Ceilometer data for an example
+filename_ceil = DATASETS.fetch('sgpceilC1.b1.20190101.000000.nc')
+ds = act.io.arm.read_arm_netcdf(filename_ceil)
+
+# Apply corrections to the dataset
+ds = act.corrections.correct_ceil(ds, var_name='backscatter')
+
+# Estimate PBL Height via a gradient method
+ds = act.retrievals.pbl_lidar.calculate_gradient_pbl(ds, parm="backscatter", smooth_dis=3)
+
+# Estimate PBL Height via a modified gradient method
+ds = act.retrievals.pbl_lidar.calculate_modified_gradient_pbl(
+    ds, parm="backscatter", threshold=1e-4, smooth_dis=3
+)
+
+# Plot the pbl height estimates
+display = act.plotting.TimeSeriesDisplay(ds, subplot_shape=(2,), figsize=(10, 8))
+
+# plot the CL backscatter before overlaying the Gradient Method PBL Height
+display.plot(
+    'backscatter',
+    subplot_index=(0,),
+    cmap='ChaseSpectral',
+    vmin=-6,
+    vmax=6,
+    set_title='SGP Ceilometer PBL Height Estimate via Gradient Method',
+)
+
+# overlay the PBL Height estimate, compute ~10min temporal averages
+display.axes[0].plot(
+    ds['time'].values,
+    ds['pbl_gradient'].rolling(time=38, min_periods=3, center=True).mean().values,
+    color='k',
+)
+# shorten the range
+display.set_yrng([0, 2000], subplot_index=(0,))
+
+# plot the CL backscatter before overlaying the Modified Gradient PBL Height
+display.plot(
+    'backscatter',
+    subplot_index=(1,),
+    cmap='ChaseSpectral',
+    vmin=-6,
+    vmax=6,
+    set_title='SGP Ceilometer PBL Height Estimate via Modified Gradient Method',
+)
+
+# overlay the PBL Height estimate, compute ~10min temporal averages
+display.axes[1].plot(
+    ds['time'].values,
+    ds['pbl_mod_gradient'].rolling(time=38, min_periods=3, center=True).mean().values,
+    color='k',
+)
+# shorten the range
+display.set_yrng([0, 2000], subplot_index=(1,))

--- a/tests/retrievals/test_pbl_lidar.py
+++ b/tests/retrievals/test_pbl_lidar.py
@@ -1,0 +1,50 @@
+import numpy as np
+
+import act
+from arm_test_data import DATASETS
+
+
+def test_calculate_gradient_pbl():
+    # Read and apply connections
+    ds = act.io.arm.read_arm_netcdf(DATASETS.fetch('sgpceilC1.b1.20190101.000000.nc'))
+    ds = act.corrections.correct_ceil(ds, var_name='backscatter')
+
+    # Call the Retrieval
+    ds = act.retrievals.pbl_lidar.calculate_gradient_pbl(
+        ds, parm="backscatter", smooth_dis=3, min_height=200
+    )
+
+    # create a subset for testing
+    subset = ds.sel(time=slice("2019-01-01T11:30:00", "2019-01-01T11:40:00"))
+    # Test the mean of the profile for the subset time
+    np.testing.assert_array_almost_equal(subset.pbl_gradient.mean(), 436.875, decimal=3)
+    # Test the minimum PBL Height during the period
+    #   note this will test the minimum height threshold assigned
+    np.testing.assert_almost_equal(subset.pbl_gradient.min(), 225.0, 1)
+
+    # test attributes
+    assert ds['pbl_gradient'].attrs["input_parameter"] == "backscatter"
+    assert ds['pbl_gradient'].attrs["units"] == "m"
+
+
+def test_calculate_modified_gradient_pbl():
+    # Read and apply connections
+    ds = act.io.arm.read_arm_netcdf(DATASETS.fetch('sgpceilC1.b1.20190101.000000.nc'))
+    ds = act.corrections.correct_ceil(ds, var_name='backscatter')
+
+    # Call the Retrieval
+    ds = act.retrievals.pbl_lidar.calculate_modified_gradient_pbl(
+        ds, parm="backscatter", smooth_dis=3, min_height=200, threshold=1e-5
+    )
+
+    # create a subset for testing
+    subset = ds.sel(time=slice("2019-01-01T11:30:00", "2019-01-01T11:40:00"))
+    # Test the mean of the profile for the subset time
+    np.testing.assert_array_almost_equal(subset.pbl_mod_gradient.mean(), 372.631, decimal=3)
+    # Test the minimum PBL Height during the period
+    #   note this will test the minimum height threshold assigned
+    np.testing.assert_almost_equal(subset.pbl_mod_gradient.min(), 225.0, 1)
+
+    # test attributes
+    assert ds['pbl_mod_gradient'].attrs["input_parameter"] == "backscatter"
+    assert ds['pbl_mod_gradient'].attrs["units"] == "m"


### PR DESCRIPTION
Estimation of the Planetary Boundary Layer (PBL) height from a backscatter LIDAR through gradient methods:
- *calculate_gradient_pbl* utilizes the historical approach where the PBL height is identified through the identification of the first negative gradient of the backscatter profile
- *calculate_modified_gradient_pbl* builds upon this, where the first significant inflection point within the profile is identified as the PBL height, rather than the first negative gradient

Neither are expected to perform well in cloud capped boundary layers. Additional PRs will be included within the near future to address more PBL environmental conditions. 

Aim is to provide the user with the algorithms to conduct their own analysis for a given environment (we'll include a workflow example at the end to match the algorithm with the environment). 

<!-- Please remove check-list items that aren't relevant to your changes -->

- [X] Tests added
- [X] Documentation reflects changes
- [X] - _used _pre-commit__ PEP8 Standards or use of linter
- [X] Xarray Dataset or DataArray variable naming follows 'ds' or 'da' naming
