### PR TITLE
FIX: Update time units for new timedelta changes.

### DIFF
--- a/act/qc/comparison_tests.py
+++ b/act/qc/comparison_tests.py
@@ -86,7 +86,7 @@ class QCTests:
         sum_diff = np.array([], dtype=float)
         time_diff = np.array([], dtype=np.int32)
         for tm_shift in range(-1 * time_shift, time_shift + int(time_step), int(time_step)):
-            time = self_da.time.values.astype('datetime64[s]') + tm_shift
+            time = self_da.time.values.astype('datetime64[s]') + np.timedelta64(int(tm_shift), 's')
             time = time.astype('datetime64[ns]')
             self_da_shifted = self_da.assign_coords(time=time)
 

--- a/act/utils/data_utils.py
+++ b/act/utils/data_utils.py
@@ -475,8 +475,9 @@ def add_in_nan(time, data):
             else:
                 # For 2D plots need to add a NaN right after and right before the data
                 # to correctly mitigate streaking with pcolormesh.
-                time_added_1 = time[corr_i] + 1  # One time step after
-                time_added_2 = time[corr_i + 1] - 1  # One time step before
+                unit, _ = np.datetime_data(time.dtype)
+                time_added_1 = time[corr_i] + np.timedelta64(1, unit)  # One time step after
+                time_added_2 = time[corr_i + 1] - np.timedelta64(1, unit)  # One time step before
                 time = np.insert(time, corr_i + 1, [time_added_1, time_added_2])
                 data = np.insert(data, corr_i + 1, np.nan, axis=0)
                 data = np.insert(data, corr_i + 2, np.nan, axis=0)

--- a/tests/io/test_arm.py
+++ b/tests/io/test_arm.py
@@ -2,6 +2,7 @@ import tempfile
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 import act
 from act.tests import sample_files
@@ -13,7 +14,7 @@ def test_read_arm_netcdf():
     assert 'rh_mean' in ds.variables.keys()
     assert ds.attrs['_arm_standards_flag'] == (1 << 0)
 
-    with np.testing.assert_raises(OSError):
+    with pytest.raises(OSError):
         ds = act.io.arm.read_arm_netcdf([])
 
     ds = act.io.arm.read_arm_netcdf([], return_None=True)
@@ -154,12 +155,12 @@ def test_io_dod():
         assert 'moment1' in ds
         assert len(ds['base_time'].values) == 1440
         assert len(ds['drop_diameter'].values) == 50
-        with np.testing.assert_warns(UserWarning):
+        with pytest.warns(UserWarning):
             ds2 = act.io.arm.create_ds_from_arm_dod('vdis.b1', dims, scalar_fill_dim='time')
         assert 'moment1' in ds2
         assert len(ds2['base_time'].values) == 1440
         assert len(ds2['drop_diameter'].values) == 50
-        with np.testing.assert_raises(ValueError):
+        with pytest.raises(ValueError):
             ds = act.io.arm.create_ds_from_arm_dod('vdis.b1', {}, version='1.2')
         ds = act.io.arm.create_ds_from_arm_dod(
             sample_files.EXAMPLE_DOD, dims, version=1.2, scalar_fill_dim='time', local_file=True

--- a/tests/utils/test_datetime_utils.py
+++ b/tests/utils/test_datetime_utils.py
@@ -13,7 +13,7 @@ def test_dates_between():
     start_string = datetime.strptime(start_date, '%Y%m%d').strftime('%Y-%m-%d')
     end_string = datetime.strptime(end_date, '%Y%m%d').strftime('%Y-%m-%d')
     answer = np.arange(start_string, end_string, dtype='datetime64[D]')
-    answer = np.append(answer, answer[-1] + 1)
+    answer = np.append(answer, answer[-1] + np.timedelta64(1, 'D'))
     answer = answer.astype('datetime64[s]').astype(int)
     answer = [datetime.fromtimestamp(ii, tz=timezone.utc).replace(tzinfo=None) for ii in answer]
 


### PR DESCRIPTION

- [x] Documentation reflects changes
- [x] PEP8 Standards or use of linter
- [x] Xarray Dataset or DataArray variable naming follows 'ds' or 'da' naming
