### PR TITLE
ADD: reader for mfrsr7nchaod files

### DIFF
--- a/act/io/__init__.py
+++ b/act/io/__init__.py
@@ -27,6 +27,7 @@ __getattr__, __dir__, __all__ = lazy.attach(
             'read_arm_netcdf',
             'check_if_tar_gz_file',
             'read_arm_mmcr',
+            'read_arm_mfrsr7nchaod',
         ],
         'ameriflux': ['convert_to_ameriflux', 'read_ameriflux'],
         'text': ['read_csv'],

--- a/act/io/arm.py
+++ b/act/io/arm.py
@@ -908,3 +908,88 @@ def read_arm_mmcr(filenames):
             ds[new_var_name] = da
 
     return ds
+
+
+def read_arm_mfrsr7nchaod(filenames):
+    """
+
+    Reads in mfrsr7nchaod files and merges along time dimension. MFRSR7NCHAOD files have
+    coordinate dimensions Io_interquartile_time and Io_gauss_time that cannot be concatenated
+    in xarray.open_mfdataset() due to overlapping values within adjacent files.
+
+    Parameters
+    ----------
+    filenames : str, pathlib.PosixPath, or list of str
+        Name(s) of fullpath(s) to read.
+
+    Returns
+    -------
+    ds : xarray.Dataset or None
+        ACT Xarray Dataset. If no files found will return None.
+    """
+
+    # Sort files in correct order for merging
+    if not isinstance(filenames, list):
+        filenames = [filenames]
+    filenames.sort()
+
+    multi_ds = []
+
+    # Open Datasets of files and add to list
+    for f in filenames:
+        try:
+            obj = xr.open_dataset(f)
+            if obj is not None:
+                multi_ds.append(obj)
+        except FileNotFoundError:
+            continue
+
+    # Merge objects
+    if len(multi_ds) > 1:
+        ds = xr.merge(multi_ds, compat="minimal")
+    elif len(multi_ds) == 1:
+        ds = multi_ds[0]
+    else:
+        ds = None
+
+    # Adding support for wildcards
+    if isinstance(filenames, str):
+        filenames = glob.glob(filenames)
+    elif isinstance(filenames, PosixPath):
+        filenames = [filenames]
+
+    # Adding attributes for file dates, file times, datastream, and flag for arm standards
+    # Get file dates and times that were read in to the dataset
+    file_dates = []
+    file_times = []
+    for f in filenames:
+        f = Path(f).name
+        pts = re.match(r'(^[a-zA-Z0-9]+)\.([0-9a-z]{2})\.([\d]{8})\.([\d]{6})\.([a-z]{2,3}$)', f)
+        # If Not ARM format, read in first time for info
+        if pts is not None:
+            pts = pts.groups()
+            file_dates.append(pts[2])
+            file_times.append(pts[3])
+        else:
+            if len(ds['time'].shape) > 0:
+                dummy = ds['time'].values[0]
+            else:
+                dummy = ds['time'].values
+            file_dates.append(utils.numpy_to_arm_date(dummy))
+            file_times.append(utils.numpy_to_arm_date(dummy, returnTime=True))
+
+    # Add attributes
+    ds.attrs['_file_dates'] = file_dates
+    ds.attrs['_file_times'] = file_times
+    is_arm_file_flag = check_arm_standards(ds)
+
+    # Ensure that we have _datastream set whether or no there's
+    # a datastream attribute already.
+    if is_arm_file_flag == 0:
+        ds.attrs['_datastream'] = DEFAULT_DATASTREAM_NAME
+    else:
+        ds.attrs['_datastream'] = ds.attrs['datastream']
+
+    ds.attrs['_arm_standards_flag'] = is_arm_file_flag
+
+    return ds

--- a/act/tests/__init__.py
+++ b/act/tests/__init__.py
@@ -67,6 +67,7 @@ __getattr__, __dir__, __all__ = lazy.attach(
             'EXAMPLE_AMERIFLUX_BASE',
             'EXAMPLE_AMERIFLUX_META',
             'EXAMPLE_SMPS',
+            'EXAMPLE_MFRSR7NCHAOD',
         ]
     },
 )

--- a/act/tests/sample_files.py
+++ b/act/tests/sample_files.py
@@ -160,3 +160,10 @@ EXAMPLE_GML_AEROSOL_NAS = DATASETS.fetch(
 )
 
 EXAMPLE_SMPS = DATASETS.fetch('houmergedsmpsapsmlM1.c1.20220801.000000.nc')
+
+mfrsr7nchaod_list = [
+    'sgpmfrsr7nchaod1michC1.c1.20260603.000000.nc',
+    'sgpmfrsr7nchaod1michC1.c1.20260602.000000.nc',
+    'sgpmfrsr7nchaod1michC1.c1.20260601.000000.nc',
+]
+EXAMPLE_MFRSR7NCHAOD = [DATASETS.fetch(file) for file in mfrsr7nchaod_list]

--- a/tests/io/test_arm.py
+++ b/tests/io/test_arm.py
@@ -293,3 +293,34 @@ def test_read_mmcr():
     assert 'SpectralWidth_BL' in ds
     np.testing.assert_almost_equal(ds['Reflectivity_GE'].mean(), -34.62, decimal=2)
     np.testing.assert_almost_equal(ds['MeanDopplerVelocity_Receiver1'].max(), 9.98, decimal=2)
+
+
+def test_read_mfrsr7nchaod():
+    results = act.tests.EXAMPLE_MFRSR7NCHAOD
+    ds = act.io.arm.read_arm_mfrsr7nchaod(results)
+    ds.load()
+
+    assert ds is not None
+    assert 'Io_gauss_time' in ds.coords
+    assert 'Io_interquartile_time' in ds.coords
+    assert isinstance(ds.attrs['_file_dates'], list)
+    assert len(ds.attrs['_file_dates']) == 3
+    assert isinstance(ds.attrs['_file_times'], list)
+    assert len(ds.attrs['_file_times']) == 3
+    assert ds.attrs['_datastream'] == 'sgpmfrsr7nchaod1michC1.c1'
+    assert ds.attrs['_arm_standards_flag'] == 1
+
+    ds.close()
+    del ds
+
+    ds = act.io.arm.read_arm_mfrsr7nchaod(results[0])
+    ds.load()
+
+    assert ds is not None
+    assert isinstance(ds.attrs['_file_dates'], list)
+    assert len(ds.attrs['_file_dates']) == 1
+    assert isinstance(ds.attrs['_file_times'], list)
+    assert len(ds.attrs['_file_times']) == 1
+
+    ds.close()
+    del ds


### PR DESCRIPTION
Adding reader for MFRSRAOD files. Will read in a list of filenames, open xarray Datasets of each file, and merge all Datasets along time dimension. Coordinate variable `Io_gauss_time` will have the union of date values from all read files. 

Added `mfrsr7nchaod1mich` files from SGP C1 to `arm-test-data` in order to complete testing.
 

- [X] Closes #1018 
- [X] Tests added
- [X] Documentation reflects changes
- [X] PEP8 Standards or use of linter
- [X] Xarray Dataset or DataArray variable naming follows 'ds' or 'da' naming
